### PR TITLE
Add pyOpenSSL dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
         "google-api-python-client >= 1.2",
         "oauth2client >= 4.0.0",
         "PyYAML >= 3.0",
-        "httplib2 <= 0.15.0"
+        "httplib2 <= 0.15.0",
+        "pyOpenSSL => 19.1.0"
     ],
     extras_require={
         "tests": ["timeout-decorator"],


### PR DESCRIPTION
pyOpenSSL library should be available to enable p12 key files support (used to auth into Google Service accounts)