### PR TITLE
Use HTTPError as cause for file download

### DIFF
--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -537,7 +537,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
     """
     resp, content = self.http.request(url)
     if resp.status != 200:
-      raise ApiRequestError('Cannot download file: %s' % resp)
+      raise ApiRequestError(errors.HttpError(resp, content, uri=url))
     return content
 
   @LoadAuth


### PR DESCRIPTION
We rely on analyzing HTTPError cause in all API calls to retry. This is the only one (but very important - download), that was not using HTTPError, but a string due to some difference in the way it is called in code.

It affects DVC pull retrying properly when it hits user limits when we deal with large number of files.