### PR TITLE
Added shared drives support for insert permissions

### DIFF
--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -362,7 +362,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
         try:
             permission = (
                 self.auth.service.permissions()
-                .insert(fileId=file_id, body=new_permission)
+                .insert(fileId=file_id, body=new_permission, supportsAllDrives=True)
                 .execute(http=self.http)
             )
         except errors.HttpError as error:


### PR DESCRIPTION
Found insert permissions were not working for shared drive files so added parameter to support it.