### PR TITLE
don't set http.redirect_codes if the attr doesn't exist

### DIFF
--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -586,7 +586,12 @@ class GoogleAuth(ApiAttributeMixin, object):
         # This asks httplib2 to exclude 308s from the status codes
         # it treats as redirects
         # See also: https://stackoverflow.com/a/59850170/298182
-        http.redirect_codes = http.redirect_codes - {308}
+        try:
+            http.redirect_codes = http.redirect_codes - {308}
+        except AttributeError:
+            # http.redirect_codes does not exist in previous versions
+            # of httplib2, so pass
+            pass
         return http
 
     def Authorize(self):


### PR DESCRIPTION
The http.redirect_codes attribute does not exist in old versions of httplib2.