### PR TITLE
file.GetContentFile: stream to disk, add callback

### DIFF
--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -238,6 +238,8 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
     :raises: ApiRequestError, FileNotUploadedError, FileNotDownloadableError
     """
         files = self.auth.service.files()
+        if mimetype is None:
+            mimetype = self.metadata.get("mimeType") or self.get("mimeType")
         get = (
             files.get_media
             if mimetype is None

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -237,14 +237,13 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
     :type param: callable
     :raises: ApiRequestError, FileNotUploadedError, FileNotDownloadableError
     """
-        file_id = self.metadata.get("id") or self.get("id")
         files = self.auth.service.files()
         get = (
             files.get_media
             if mimetype is None
             else partial(files.export_media, mimeType=mimetype)
         )
-        request = get(fileId=file_id)
+        request = get(fileId=self.metadata.get("id") or self.get("id"))
         with open(filename, mode="w+b") as fd:
             downloader = MediaIoBaseDownload(fd, request)
             done = False

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -276,9 +276,13 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
 
             if mimetype == "text/plain" and remove_bom:
                 fd.seek(0)
-                self._RemovePrefix(
-                    fd, MIME_TYPE_TO_BOM[self["mimeType"]][mimetype]
-                )
+                boms = [
+                    bom[mimetype]
+                    for bom in MIME_TYPE_TO_BOM.values()
+                    if mimetype in bom
+                ]
+                if boms:
+                    self._RemovePrefix(fd, boms[0].encode("utf8"))
 
     @LoadAuth
     def FetchMetadata(self, fields=None, fetch_all=False):

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -238,7 +238,9 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
     :raises: ApiRequestError, FileNotUploadedError, FileNotDownloadableError
     """
         file_id = self.metadata.get("id") or self.get("id")
-        request = self.auth.service.files().get_media(fileId=file_id)
+        files = self.auth.service.files()
+        get = files.get_media if mimetype is None else files.export_media
+        request = get(fileId=file_id)
         with open(filename, mode="w+b") as fd:
             downloader = MediaIoBaseDownload(fd, request)
             done = False

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -5,7 +5,7 @@ import json
 from googleapiclient import errors
 from googleapiclient.http import MediaIoBaseUpload
 from googleapiclient.http import MediaIoBaseDownload
-from functools import wraps
+from functools import wraps, partial
 
 from .apiattr import ApiAttribute
 from .apiattr import ApiAttributeMixin
@@ -239,7 +239,11 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
     """
         file_id = self.metadata.get("id") or self.get("id")
         files = self.auth.service.files()
-        get = files.get_media if mimetype is None else files.export_media
+        get = (
+            files.get_media
+            if mimetype is None
+            else partial(files.export_media, mimeType=mimetype)
+        )
         request = get(fileId=file_id)
         with open(filename, mode="w+b") as fd:
             downloader = MediaIoBaseDownload(fd, request)

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -282,7 +282,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
                     if mimetype in bom
                 ]
                 if boms:
-                    self._RemovePrefix(fd, boms[0].encode("utf8"))
+                    self._RemovePrefix(fd, boms[0])
 
     @LoadAuth
     def FetchMetadata(self, fields=None, fetch_all=False):

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -238,13 +238,12 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
     :raises: ApiRequestError, FileNotUploadedError, FileNotDownloadableError
     """
         files = self.auth.service.files()
+        get = files.get_media
         if mimetype is None:
             mimetype = self.metadata.get("mimeType") or self.get("mimeType")
-        get = (
-            files.get_media
-            if mimetype is None
-            else partial(files.export_media, mimeType=mimetype)
-        )
+            if mimetype.startswith("application/vnd.google-apps."):
+                mimetype = "text/plain"  # or "application/octet-stream"?
+                get = partial(files.export_media, mimeType=mimetype)
         request = get(fileId=self.metadata.get("id") or self.get("id"))
         with open(filename, mode="w+b") as fd:
             downloader = MediaIoBaseDownload(fd, request)

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -239,11 +239,12 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
     """
         files = self.auth.service.files()
         get = files.get_media
-        if mimetype is None:
-            mimetype = self.metadata.get("mimeType") or self.get("mimeType")
-            if mimetype.startswith("application/vnd.google-apps."):
-                mimetype = "text/plain"  # or "application/octet-stream"?
-                get = partial(files.export_media, mimeType=mimetype)
+        # patch `get` for docs files
+        meta_mimeType = self.metadata.get("mimeType") or self.get("mimeType")
+        if meta_mimeType.startswith("application/vnd.google-apps."):
+            mimetype = mimetype or "text/plain"
+            get = partial(files.export_media, mimeType=mimetype)
+
         request = get(fileId=self.metadata.get("id") or self.get("id"))
         with open(filename, mode="w+b") as fd:
             downloader = MediaIoBaseDownload(fd, request)

--- a/pydrive2/test/test_file.py
+++ b/pydrive2/test/test_file.py
@@ -487,7 +487,7 @@ class GoogleDriveFileTest(unittest.TestCase):
         downloaded_file_name = "_tmp_downloaded_file_name.txt"
         pydrive_retry(
             lambda: file1.GetContentFile(
-                downloaded_file_name, mimetype="text/plain"
+                downloaded_file_name, mimetype="text/plain", remove_bom=True
             )
         )
         downloaded_string = open(downloaded_file_name).read()

--- a/pydrive2/test/test_util.py
+++ b/pydrive2/test/test_util.py
@@ -48,11 +48,7 @@ def pydrive_retry(call):
     try:
         result = call()
     except ApiRequestError as exception:
-        retry_codes = ["403", "500", "502", "503", "504"]
-        if any(
-            "HttpError {}".format(code) in str(exception)
-            for code in retry_codes
-        ):
+        if exception.error["code"] in [403, 500, 502, 503, 504]:
             raise PyDriveRetriableError("Google API request failed")
         raise
     return result


### PR DESCRIPTION
- [x] stop `GetContentFile` temporarily keeping the whole file in RAM
- [x] add an optional `callback` for external progress monitoring
- [x] fix gsuite (export) files
  - [x] avoid slow API calls to check metadata
- [x] fix BOM test (seems to expect BOM stripping even when `remove_bom=False`. May be a breaking change to modify this test?)
- reference: https://developers.google.com/drive/api/v2/manage-downloads
- reference: https://developers.google.com/drive/api/v2/mime-types

And the (`pydrive2`) docstrings did say:

> `:returns: str -- utf-8 decoded content of the file`

And again, it (`httplib2`) said:

> `The return value is [...] a string that contains the response entity body.`

And the devs did shudder. There was wailing in the North and South. There was gnashing of teeth in the East and West.

And then one brave dev, in a quavering voice, spake thusly:

> Let there be no more in-memory downloads. Let the files stream until the hard drives overfloweth. Let RAM be ignored, and let us answer the call to progress.


- fixes #28
- related #20
- closes #29