### PR TITLE
add files.GetContentIOBuffer

### DIFF
--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -23,6 +23,13 @@ MIME_TYPE_TO_BOM = {
 }
 
 
+def GetBom(mimetype):
+    """Based on download mime type (ignores Google Drive mime type)"""
+    for bom in MIME_TYPE_TO_BOM.values():
+        if mimetype in bom:
+            return bom[mimetype]
+
+
 class FileNotUploadedError(RuntimeError):
     """Error trying to access metadata of file that is not uploaded."""
 
@@ -353,11 +360,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
 
             if mimetype == "text/plain" and remove_bom:
                 fd.seek(0)
-                boms = [
-                    bom[mimetype]
-                    for bom in MIME_TYPE_TO_BOM.values()
-                    if mimetype in bom
-                ]
+                boms = GetBom(mimetype)
                 if boms:
                     self._RemovePrefix(fd, boms[0])
 
@@ -410,11 +413,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
                 )
                 remove_prefix = b""
                 if mimetype == "text/plain" and remove_bom:
-                    boms = [
-                        bom[mimetype]
-                        for bom in MIME_TYPE_TO_BOM.values()
-                        if mimetype in bom
-                    ]
+                    boms = GetBom(mimetype)
                     if boms:
                         remove_prefix = boms[0]
                 return MediaIoReadable(

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -142,7 +142,7 @@ class MediaIoReadable(object):
 
     def read(self):
         """
-    :returns: str -- chunk or None if done
+    :returns: bytes or str -- chunk (or None if done)
     :raises: ApiRequestError
     """
         if self._pre_buffer:
@@ -155,6 +155,13 @@ class MediaIoReadable(object):
         except errors.HttpError as error:
             raise ApiRequestError(error)
         return self._fd.read()
+
+    def __iter__(self):
+        while True:
+            chunk = self.read()
+            if chunk is None:
+                break
+            yield chunk
 
 
 class GoogleDriveFile(ApiAttributeMixin, ApiResource):

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -140,7 +140,7 @@ class MediaIoReadable(object):
             self.read()
             self._pre_buffer = True
 
-    def read(self, chunksize=DEFAULT_CHUNK_SIZE):
+    def read(self):
         """
     :returns: str -- chunk or None if done
     :raises: ApiRequestError
@@ -150,8 +150,6 @@ class MediaIoReadable(object):
             return self._fd.read()
         if self.done:
             return None
-        if chunksize:
-            self.downloader._chunksize = chunksize
         try:
             _, self.done = self.downloader.next_chunk()
         except errors.HttpError as error:

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -23,7 +23,7 @@ MIME_TYPE_TO_BOM = {
 }
 
 
-def GetBom(mimetype):
+def GetBOM(mimetype):
     """Based on download mime type (ignores Google Drive mime type)"""
     for bom in MIME_TYPE_TO_BOM.values():
         if mimetype in bom:
@@ -360,9 +360,9 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
 
             if mimetype == "text/plain" and remove_bom:
                 fd.seek(0)
-                boms = GetBom(mimetype)
-                if boms:
-                    self._RemovePrefix(fd, boms[0])
+                bom = GetBOM(mimetype)
+                if bom:
+                    self._RemovePrefix(fd, bom)
 
     @LoadAuth
     def GetContentIOBuffer(
@@ -413,9 +413,9 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
                 )
                 remove_prefix = b""
                 if mimetype == "text/plain" and remove_bom:
-                    boms = GetBom(mimetype)
-                    if boms:
-                        remove_prefix = boms[0]
+                    bom = GetBOM(mimetype)
+                    if bom:
+                        remove_prefix = bom
                 return MediaIoReadable(
                     request,
                     encoding=encoding,

--- a/pydrive2/test/test_file.py
+++ b/pydrive2/test/test_file.py
@@ -628,6 +628,23 @@ class GoogleDriveFileTest(unittest.TestCase):
             self.assertNotEqual(content_bom, content_no_bom)
             self.assertTrue(len(content_bom) > len(content_no_bom))
 
+            buffer_bom = pydrive_retry(
+                file1.GetContentIOBuffer,
+                mimetype="text/plain",
+                encoding="ascii",
+            )
+            buffer_bom = "".join(iter(buffer_bom))
+            buffer_no_bom = pydrive_retry(
+                file1.GetContentIOBuffer,
+                mimetype="text/plain",
+                remove_bom=True,
+                encoding="ascii",
+            )
+            buffer_no_bom = "".join(iter(buffer_no_bom))
+
+            self.assertEqual(content_bom, buffer_bom)
+            self.assertNotEqual(content_no_bom, buffer_no_bom)
+
         finally:
             self.cleanup_gfile_conversion_test(
                 file1, file_name, downloaded_file_name

--- a/pydrive2/test/test_file.py
+++ b/pydrive2/test/test_file.py
@@ -631,16 +631,16 @@ class GoogleDriveFileTest(unittest.TestCase):
             buffer_bom = pydrive_retry(
                 file1.GetContentIOBuffer,
                 mimetype="text/plain",
-                encoding="ascii",
+                encoding="utf-8",
             )
-            buffer_bom = "".join(iter(buffer_bom))
+            buffer_bom = u"".join(iter(buffer_bom))
             buffer_no_bom = pydrive_retry(
                 file1.GetContentIOBuffer,
                 mimetype="text/plain",
                 remove_bom=True,
-                encoding="ascii",
+                encoding="utf-8",
             )
-            buffer_no_bom = "".join(iter(buffer_no_bom))
+            buffer_no_bom = u"".join(iter(buffer_no_bom))
 
             self.assertEqual(content_bom, buffer_bom)
             self.assertNotEqual(content_no_bom, buffer_no_bom)

--- a/pydrive2/test/test_file.py
+++ b/pydrive2/test/test_file.py
@@ -634,6 +634,8 @@ class GoogleDriveFileTest(unittest.TestCase):
                 encoding="utf-8",
             )
             buffer_bom = u"".join(iter(buffer_bom))
+            self.assertEqual(content_bom, buffer_bom)
+
             buffer_no_bom = pydrive_retry(
                 file1.GetContentIOBuffer,
                 mimetype="text/plain",
@@ -641,9 +643,7 @@ class GoogleDriveFileTest(unittest.TestCase):
                 encoding="utf-8",
             )
             buffer_no_bom = u"".join(iter(buffer_no_bom))
-
-            self.assertEqual(content_bom, buffer_bom)
-            self.assertNotEqual(content_no_bom, buffer_no_bom)
+            self.assertEqual(content_no_bom, buffer_no_bom)
 
         finally:
             self.cleanup_gfile_conversion_test(

--- a/pydrive2/test/test_file.py
+++ b/pydrive2/test/test_file.py
@@ -280,6 +280,24 @@ class GoogleDriveFileTest(unittest.TestCase):
 
         self.DeleteUploadedFiles(drive, [file1["id"]])
 
+    def test_11_Files_Get_Content_Buffer(self):
+        drive = GoogleDrive(self.ga)
+        file1 = drive.CreateFile()
+        filename = self.getTempFile()
+        content = "hello world!\ngoodbye, cruel world!"
+        file1["title"] = filename
+        file1.SetContentString(content)
+        pydrive_retry(file1.Upload)  # Files.insert
+
+        buffer1 = pydrive_retry(file1.GetContentIOBuffer)
+        self.assertEqual(file1.metadata["title"], filename)
+        self.assertEqual(b"".join(iter(buffer1)).decode("ascii"), content)
+
+        buffer2 = pydrive_retry(file1.GetContentIOBuffer, encoding="ascii")
+        self.assertEqual("".join(iter(buffer2)), content)
+
+        self.DeleteUploadedFiles(drive, [file1["id"]])
+
     # Tests for Trash/UnTrash/Delete.
     # ===============================
 


### PR DESCRIPTION
- [x] add `GetContentIOBuffer` returning a `read()`able object
  + [x] add `mimetype`
  + [x] add `encoding`
  + [x] add `__iter__` to make it easier to wrap à la https://github.com/iterative/dvc/blob/516d82e41107438756797611bbb15614cd4d989f/dvc/utils/http.py#L66
  + [x] add `remove_bom`
- [x] ~~add `SetContentIOBuffer` returning a `write()`able object~~
- [x] test
- fixes #38