### PR TITLE
bump google-api-python-client version to the latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
     description="Google Drive API made easy. Maintained fork of PyDrive.",
     long_description=open("README.rst").read(),
     install_requires=[
-        "google-api-python-client >= 1.7.12",
+        "google-api-python-client >= 1.12.1",
+        "six >= 1.13.0",
         "oauth2client >= 4.0.0",
         "PyYAML >= 3.0",
         "pyOpenSSL >= 19.1.0",


### PR DESCRIPTION
There was a recent release 1.12.0 which broke because of its dependency with `six`,
and there has been another patch update `1.12.1` which fixes that. I could have just forbidden
`1.12.0`, but didn't trust other versions and tried to just use the latest version.

Recent release with the fix: https://github.com/googleapis/google-api-python-client/releases/tag/v1.12.1