### PR TITLE
Support authentication from json service account file

### DIFF
--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -296,14 +296,21 @@ class GoogleAuth(ApiAttributeMixin, object):
         if set(self.SERVICE_CONFIGS_LIST) - set(self.client_config):
             self.LoadServiceConfigSettings()
         scopes = scopes_to_string(self.settings["oauth_scope"])
+        client_service_json = self.client_config.get("client_service_json")
+        if client_service_json:
+            self.credentials = ServiceAccountCredentials.from_json_keyfile_name(
+                filename=client_service_json, scopes=scopes
+            )
+        else:
+            service_email = self.client_config["client_service_email"]
+            file_path = self.client_config["client_pkcs12_file_path"]
+            self.credentials = ServiceAccountCredentials.from_p12_keyfile(
+                service_account_email=service_email,
+                filename=file_path,
+                scopes=scopes,
+            )
+
         user_email = self.client_config.get("client_user_email")
-        service_email = self.client_config["client_service_email"]
-        file_path = self.client_config["client_pkcs12_file_path"]
-        self.credentials = ServiceAccountCredentials.from_p12_keyfile(
-            service_account_email=service_email,
-            filename=file_path,
-            scopes=scopes,
-        )
         if user_email:
             self.credentials = self.credentials.create_delegated(
                 sub=user_email

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -161,11 +161,7 @@ class GoogleAuth(ApiAttributeMixin, object):
         "revoke_uri",
         "redirect_uri",
     ]
-    SERVICE_CONFIGS_LIST = [
-        "client_service_email",
-        "client_user_email",
-        "client_pkcs12_file_path",
-    ]
+    SERVICE_CONFIGS_LIST = ["client_service_email", "client_user_email"]
     settings = ApiAttribute("settings")
     client_config = ApiAttribute("client_config")
     flow = ApiAttribute("flow")
@@ -296,7 +292,9 @@ class GoogleAuth(ApiAttributeMixin, object):
         if set(self.SERVICE_CONFIGS_LIST) - set(self.client_config):
             self.LoadServiceConfigSettings()
         scopes = scopes_to_string(self.settings["oauth_scope"])
-        client_service_json = self.client_config.get("client_service_json")
+        client_service_json = self.client_config.get(
+            "client_service_json_file_path"
+        )
         if client_service_json:
             self.credentials = ServiceAccountCredentials.from_json_keyfile_name(
                 filename=client_service_json, scopes=scopes
@@ -488,6 +486,18 @@ class GoogleAuth(ApiAttributeMixin, object):
                 err += "\n\nMissing: {} key.".format(config)
                 raise InvalidConfigError(err)
 
+        for file_format in ["json", "pkcs12"]:
+            config = f"client_{file_format}_file_path"
+            value = self.settings["service_config"].get(config)
+            if value:
+                self.client_config[config] = value
+                break
+        else:
+            raise InvalidConfigError(
+                "Either json or pkcs12 file path required "
+                "for service authentication"
+            )
+
     def LoadClientConfigSettings(self):
         """Loads client configuration from settings file.
 
@@ -523,7 +533,7 @@ class GoogleAuth(ApiAttributeMixin, object):
             self.client_config["client_id"],
             self.client_config["client_secret"],
             scopes_to_string(self.settings["oauth_scope"]),
-            **constructor_kwargs
+            **constructor_kwargs,
         )
         if self.settings.get("get_refresh_token"):
             self.flow.params.update(

--- a/pydrive2/test/settings/test_oauth_test_07.yaml
+++ b/pydrive2/test/settings/test_oauth_test_07.yaml
@@ -1,0 +1,11 @@
+client_config_backend: service
+service_config:
+  client_service_email: your-service-account-email
+  client_service_json_file_path: your-file-path.json
+
+save_credentials: True
+save_credentials_backend: file
+save_credentials_file: credentials/7.dat
+
+oauth_scope:
+  - https://www.googleapis.com/auth/drive

--- a/pydrive2/test/test_oauth.py
+++ b/pydrive2/test/test_oauth.py
@@ -73,9 +73,16 @@ class GoogleAuthTest(unittest.TestCase):
         self.assertEqual(ga.access_token_expired, False)
         time.sleep(1)
 
-    def test_06_ServiceAuthFromSavedCredentialsFile(self):
+    def test_06_ServiceAuthFromSavedCredentialsP12File(self):
         setup_credentials("credentials/6.dat")
         ga = GoogleAuth(settings_file_path("test_oauth_test_06.yaml"))
+        ga.ServiceAuth()
+        self.assertEqual(ga.access_token_expired, False)
+        time.sleep(1)
+
+    def test_07_ServiceAuthFromSavedCredentialsJsonFile(self):
+        setup_credentials("credentials/7.dat")
+        ga = GoogleAuth(settings_file_path("test_oauth_test_07.yaml"))
         ga.ServiceAuth()
         self.assertEqual(ga.access_token_expired, False)
         time.sleep(1)


### PR DESCRIPTION
Authentication with p12 seems to be deprecated, and won't present in future oauth clients (like google.oauth2, which replaces deprecated `oauth2client`), context:
https://github.com/googleapis/google-auth-library-python/issues/288#issuecomment-456671469

This is a problem because we want to use gdrivefs in the tests, and gdrivefs depends on pydata-google-auth which depends on google.auth2 which doesn't support p12 format since it is deprecated (too many layers of indirection, i know). I have a patch ready for the all libraries on the way, but for them with service authentication as a fixture I thought it would be good to have pydrive to support this so that we don't keep 2 forms of authentication files in the CI secrets. 