### PR TITLE
a fix for access_type

### DIFF
--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -542,6 +542,7 @@ class GoogleAuth(ApiAttributeMixin, object):
             "redirect_uri": self.client_config["redirect_uri"],
             "auth_uri": self.client_config["auth_uri"],
             "token_uri": self.client_config["token_uri"],
+            "access_type": "online",
         }
         if self.client_config["revoke_uri"] is not None:
             constructor_kwargs["revoke_uri"] = self.client_config["revoke_uri"]


### PR DESCRIPTION
seems like the default `access_type` is `offline` so I added this line to make sure that the default behavior does not get the refresh token

