### PR TITLE
setup: restrict the upperbound of google-api-python-client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     description="Google Drive API made easy. Maintained fork of PyDrive.",
     long_description=open("README.rst").read(),
     install_requires=[
-        "google-api-python-client >= 1.12.5",
+        "google-api-python-client >= 1.12.5, <2",
         "six >= 1.13.0",
         "oauth2client >= 4.0.0",
         "PyYAML >= 3.0",


### PR DESCRIPTION
It seems like pydrive is incompatible with google-api-python-cleint>=2.0 (which is actually yanked on PyPI), https://stackoverflow.com/questions/66477468/data-version-control-with-google-drive-remote-googleapiclient-errors-unknownap