### PR TITLE
auth: drop json credentials backend

### DIFF
--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -325,8 +325,6 @@ class GoogleAuth(ApiAttributeMixin, object):
                 raise InvalidConfigError("Please specify credential backend")
         if backend == "file":
             self.LoadCredentialsFile()
-        elif backend == "json":
-            self.LoadCredentialsFileJson()
         else:
             raise InvalidConfigError("Unknown save_credentials_backend")
 
@@ -352,19 +350,6 @@ class GoogleAuth(ApiAttributeMixin, object):
             raise InvalidCredentialsError(
                 "Credentials file cannot be symbolic link"
             )
-
-    def LoadCredentialsFileJson(self, credentials_file=None):
-        if credentials_file is None:
-            credentials_file = self.settings.get("save_credentials_file")
-            if credentials_file is None:
-                raise InvalidConfigError(
-                    "Please specify credentials file to read"
-                )
-
-        scopes = scopes_to_string(self.settings["oauth_scope"])
-        self.credentials = ServiceAccountCredentials.from_json_keyfile_name(
-            filename=credentials_file, scopes=scopes
-        )
 
     def SaveCredentials(self, backend=None):
         """Saves credentials according to specified backend.

--- a/pydrive2/test/settings/default.yaml
+++ b/pydrive2/test/settings/default.yaml
@@ -1,6 +1,6 @@
 client_config_backend: service
 service_config:
-  client_json_file_path: your-file-path.json
+  client_json_file_path: /tmp/pydrive2/credentials.json
 
 save_credentials: True
 save_credentials_backend: file

--- a/pydrive2/test/settings/default.yaml
+++ b/pydrive2/test/settings/default.yaml
@@ -3,7 +3,7 @@ service_config:
   client_json_file_path: your-file-path.json
 
 save_credentials: True
-save_credentials_backend: json
+save_credentials_backend: file
 save_credentials_file: credentials/default.dat
 
 oauth_scope:

--- a/pydrive2/test/settings/test_oauth_test_07.yaml
+++ b/pydrive2/test/settings/test_oauth_test_07.yaml
@@ -3,7 +3,7 @@ service_config:
   client_json_file_path: your-file-path.json
 
 save_credentials: True
-save_credentials_backend: json
+save_credentials_backend: file
 save_credentials_file: credentials/7.dat
 
 oauth_scope:

--- a/pydrive2/test/settings/test_oauth_test_07.yaml
+++ b/pydrive2/test/settings/test_oauth_test_07.yaml
@@ -1,6 +1,6 @@
 client_config_backend: service
 service_config:
-  client_json_file_path: your-file-path.json
+  client_json_file_path: /tmp/pydrive2/credentials.json
 
 save_credentials: True
 save_credentials_backend: file

--- a/pydrive2/test/test_oauth.py
+++ b/pydrive2/test/test_oauth.py
@@ -83,12 +83,12 @@ class GoogleAuthTest(unittest.TestCase):
         time.sleep(1)
 
     def test_07_ServiceAuthFromSavedCredentialsJsonFile(self):
-        # Have an initial out so that credentials/7.dat gets saved
+        # Have an initial auth so that credentials/7.dat gets saved
         ga = GoogleAuth(settings_file_path("test_oauth_test_07.yaml"))
         ga.ServiceAuth()
         self.assertTrue(os.path.exists(ga.settings["save_credentials_file"]))
 
-        # Secondary out should be made only using the previously saved
+        # Secondary auth should be made only using the previously saved
         # login info
         ga = GoogleAuth(settings_file_path("test_oauth_test_07.yaml"))
         ga.ServiceAuth()

--- a/pydrive2/test/test_oauth.py
+++ b/pydrive2/test/test_oauth.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import time
 import pytest
@@ -82,9 +83,16 @@ class GoogleAuthTest(unittest.TestCase):
         time.sleep(1)
 
     def test_07_ServiceAuthFromSavedCredentialsJsonFile(self):
-        setup_credentials("credentials/7.dat")
+        # Have an initial out so that credentials/7.dat gets saved
         ga = GoogleAuth(settings_file_path("test_oauth_test_07.yaml"))
         ga.ServiceAuth()
+        self.assertTrue(os.path.exists(ga.settings["save_credentials_file"]))
+
+        # Secondary out should be made only using the previously saved
+        # login info
+        ga = GoogleAuth(settings_file_path("test_oauth_test_07.yaml"))
+        ga.ServiceAuth()
+
         self.assertEqual(ga.access_token_expired, False)
         time.sleep(1)
 

--- a/pydrive2/test/test_util.py
+++ b/pydrive2/test/test_util.py
@@ -11,7 +11,7 @@ from shutil import copyfile, rmtree
 newline_pattern = re.compile(r"[\r\n]")
 
 GDRIVE_USER_CREDENTIALS_DATA = "GDRIVE_USER_CREDENTIALS_DATA"
-DEFAULT_USER_CREDENTIALS_FILE = "credentials/default.dat"
+DEFAULT_USER_CREDENTIALS_FILE = "/tmp/pydrive2/credentials.json"
 
 TESTS_ROOTDIR = os.path.dirname(__file__)
 SETTINGS_PATH = posixpath.join(TESTS_ROOTDIR, "settings/")


### PR DESCRIPTION
Redundantly introduced in #81, and the cause of some downstream issues. Removing per #96 