### PR TITLE
Fixes 103: fix and simplify fetch all metadata logic

### DIFF
--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -209,25 +209,6 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
             self.UpdateMetadata(metadata)
         elif metadata:
             self.update(metadata)
-        self._ALL_FIELDS = (
-            "alternateLink,appDataContents,"
-            "canComment,canReadRevisions,capabilities"
-            "copyable,createdDate,defaultOpenWithLink,description,"
-            "downloadUrl,editable,embedLink,etag,explicitlyTrashed,"
-            "exportLinks,fileExtension,fileSize,folderColorRgb,"
-            "fullFileExtension,hasAugmentedPermissions,"
-            "headRevisionId,iconLink,id,"
-            "imageMediaMetadata,indexableText,isAppAuthorized,kind,"
-            "labels,lastModifyingUser,lastModifyingUserName,"
-            "lastViewedByMeDate,markedViewedByMeDate,md5Checksum,"
-            "mimeType,modifiedByMeDate,modifiedDate,openWithLinks,"
-            "originalFilename,ownedByMe,ownerNames,owners,parents,"
-            "permissions,properties,quotaBytesUsed,selfLink,shareable,"
-            "shared,sharedWithMeDate,sharingUser,spaces,teamDriveId,"
-            "thumbnail,thumbnailLink,title,trashedDate,trashingUser"
-            "userPermission,version,videoMediaMetadata,webContentLink,"
-            "webViewLink,writersCanShare"
-        )
         self.has_bom = True
 
     def __getitem__(self, key):
@@ -449,7 +430,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
         file_id = self.metadata.get("id") or self.get("id")
 
         if fetch_all:
-            fields = self._ALL_FIELDS
+            fields = "*"
 
         if file_id:
             try:

--- a/pydrive2/test/test_file.py
+++ b/pydrive2/test/test_file.py
@@ -451,6 +451,17 @@ class GoogleDriveFileTest(unittest.TestCase):
         self.assertTrue("permissions" in file1)
         pydrive_retry(file1.Delete)
 
+    def test_Files_FetchAllMetadata_Fields(self):
+        drive = GoogleDrive(self.ga)
+        file1 = drive.CreateFile()
+        pydrive_retry(file1.Upload)
+
+        pydrive_retry(file1.FetchMetadata, fetch_all=True)
+        self.assertTrue("hasThumbnail" in file1)
+        self.assertTrue("thumbnailVersion" in file1)
+        self.assertTrue("permissions" in file1)
+        pydrive_retry(file1.Delete)
+
     def test_Files_Insert_Permission(self):
         drive = GoogleDrive(self.ga)
         file1 = drive.CreateFile()


### PR DESCRIPTION
There is a bug in the current implementation (, is missing between two fields in the _ALL_FIELDS list).

This is an attempt to simplify the logic by using * instead of _ALL_FIELDS + add tests to cover this and check presence some of the fields (e.g. permissions that are not fetched by default if * is not provided).