### PR TITLE
Fix 163: make credentials save/load thread safe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
 - hooks:
   - id: black
     language_version: python3
-  repo: https://github.com/ambv/black
+  repo: https://github.com/psf/black
   rev: 22.3.0
 - hooks:
   - id: flake8

--- a/pydrive2/test/README.rst
+++ b/pydrive2/test/README.rst
@@ -22,15 +22,10 @@ Run tests locally
       sidebar, and select **Service Accounts**. Click **+ CREATE SERVICE
       ACCOUNT**, on the next screen, enter **Service account name** e.g. "PyDrive
       tests", and click **Create**. Select **Continue** at the next **Service
-      account permissions** page, click at **+ CREATE KEY**, select **P12** and
-      **Create**. Save generated :code:`.p12` key file at your local disk.
-    - Copy downloaded :code:`p.12` file to :code:`pydrive2/test` directory.
-      Edit files :code:`pydrive2/test/settings/local/default.yaml` and
-      :code:`pydrive2/test/settings/local/test_oauth_test_06.yaml` by replacing
-      **your-service-account-email** with email of your new created service account
-      and by replacing **your-file-path.p12** with name of copied :code:`.p12` key
-      file, for example :code:`pydrive-test-270414-581c887879a3.p12`. Value for
-      **client_user_email** should be left blank.
+      account permissions** page, click at **+ CREATE KEY**, select **JSON** and
+      **Create**. Save generated :code:`.json` key file at your local disk.
+    - Copy downloaded :code:`json` file to :code:`/tmp/pydrive2/credentials.json`
+      directory.
 
 3. Optional. If you would like to use your own an OAuth client ID follow the steps:
     - Under `Google API Console <https://console.developers.google.com>`_ select
@@ -63,7 +58,7 @@ Run tests locally
 
 ::
 
-    pip install -e .[tests]
+    pip install -e .[tests,fsspec]
 
 
 5. Run tests:

--- a/pydrive2/test/settings/test_oauth_test_08.yaml
+++ b/pydrive2/test/settings/test_oauth_test_08.yaml
@@ -1,0 +1,8 @@
+client_config_backend: service
+service_config:
+  client_json_file_path: /tmp/pydrive2/credentials.json
+
+save_credentials: False
+
+oauth_scope:
+  - https://www.googleapis.com/auth/drive

--- a/pydrive2/test/settings/test_oauth_test_09.yaml
+++ b/pydrive2/test/settings/test_oauth_test_09.yaml
@@ -1,0 +1,10 @@
+client_config_backend: service
+service_config:
+  client_json_file_path: /tmp/pydrive2/credentials.json
+
+save_credentials: True
+save_credentials_backend: file
+save_credentials_file: credentials/9.dat
+
+oauth_scope:
+  - https://www.googleapis.com/auth/drive

--- a/pydrive2/test/test_oauth.py
+++ b/pydrive2/test/test_oauth.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 import time
 import pytest
 
@@ -11,96 +10,96 @@ from pydrive2.test.test_util import (
 )
 
 
-class GoogleAuthTest(unittest.TestCase):
-    """Tests basic OAuth2 operations of auth.GoogleAuth."""
-
-    @classmethod
-    def setup_class(cls):
-        setup_credentials()
-
-    @pytest.mark.manual
-    def test_01_LocalWebserverAuthWithClientConfigFromFile(self):
-        # Delete old credentials file
-        delete_file("credentials/1.dat")
-        # Test if authentication works with config read from file
-        ga = GoogleAuth(settings_file_path("test_oauth_test_01.yaml"))
-        ga.LocalWebserverAuth()
-        self.assertEqual(ga.access_token_expired, False)
-        # Test if correct credentials file is created
-        self.CheckCredentialsFile("credentials/1.dat")
-        time.sleep(1)
-
-    @pytest.mark.manual
-    def test_02_LocalWebserverAuthWithClientConfigFromSettings(self):
-        # Delete old credentials file
-        delete_file("credentials/2.dat")
-        # Test if authentication works with config read from settings
-        ga = GoogleAuth(settings_file_path("test_oauth_test_02.yaml"))
-        ga.LocalWebserverAuth()
-        self.assertEqual(ga.access_token_expired, False)
-        # Test if correct credentials file is created
-        self.CheckCredentialsFile("credentials/2.dat")
-        time.sleep(1)
-
-    @pytest.mark.manual
-    def test_03_LocalWebServerAuthWithNoCredentialsSaving(self):
-        # Delete old credentials file
-        delete_file("credentials/3.dat")
-        # Provide wrong credentials file
-        ga = GoogleAuth(settings_file_path("test_oauth_test_03.yaml"))
-        ga.LocalWebserverAuth()
-        self.assertEqual(ga.access_token_expired, False)
-        # Test if correct credentials file is created
-        self.CheckCredentialsFile("credentials/3.dat", no_file=True)
-        time.sleep(1)
-
-    @pytest.mark.manual
-    def test_04_CommandLineAuthWithClientConfigFromFile(self):
-        # Delete old credentials file
-        delete_file("credentials/4.dat")
-        # Test if authentication works with config read from file
-        ga = GoogleAuth(settings_file_path("test_oauth_test_04.yaml"))
-        ga.CommandLineAuth()
-        self.assertEqual(ga.access_token_expired, False)
-        # Test if correct credentials file is created
-        self.CheckCredentialsFile("credentials/4.dat")
-        time.sleep(1)
-
-    @pytest.mark.manual
-    def test_05_ConfigFromSettingsWithoutOauthScope(self):
-        # Test if authentication works without oauth_scope
-        ga = GoogleAuth(settings_file_path("test_oauth_test_05.yaml"))
-        ga.LocalWebserverAuth()
-        self.assertEqual(ga.access_token_expired, False)
-        time.sleep(1)
-
-    @pytest.mark.skip(reason="P12 authentication is deprecated")
-    def test_06_ServiceAuthFromSavedCredentialsP12File(self):
-        setup_credentials("credentials/6.dat")
-        ga = GoogleAuth(settings_file_path("test_oauth_test_06.yaml"))
-        ga.ServiceAuth()
-        self.assertEqual(ga.access_token_expired, False)
-        time.sleep(1)
-
-    def test_07_ServiceAuthFromSavedCredentialsJsonFile(self):
-        # Have an initial auth so that credentials/7.dat gets saved
-        ga = GoogleAuth(settings_file_path("test_oauth_test_07.yaml"))
-        ga.ServiceAuth()
-        self.assertTrue(os.path.exists(ga.settings["save_credentials_file"]))
-
-        # Secondary auth should be made only using the previously saved
-        # login info
-        ga = GoogleAuth(settings_file_path("test_oauth_test_07.yaml"))
-        ga.ServiceAuth()
-
-        self.assertEqual(ga.access_token_expired, False)
-        time.sleep(1)
-
-    def CheckCredentialsFile(self, credentials, no_file=False):
-        ga = GoogleAuth(settings_file_path("test_oauth_default.yaml"))
-        ga.LoadCredentialsFile(credentials)
-        self.assertEqual(ga.access_token_expired, no_file)
+def setup_module(module):
+    setup_credentials()
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.manual
+def test_01_LocalWebserverAuthWithClientConfigFromFile():
+    # Delete old credentials file
+    delete_file("credentials/1.dat")
+    # Test if authentication works with config read from file
+    ga = GoogleAuth(settings_file_path("test_oauth_test_01.yaml"))
+    ga.LocalWebserverAuth()
+    assert not ga.access_token_expired
+    # Test if correct credentials file is created
+    CheckCredentialsFile("credentials/1.dat")
+    time.sleep(1)
+
+
+@pytest.mark.manual
+def test_02_LocalWebserverAuthWithClientConfigFromSettings():
+    # Delete old credentials file
+    delete_file("credentials/2.dat")
+    # Test if authentication works with config read from settings
+    ga = GoogleAuth(settings_file_path("test_oauth_test_02.yaml"))
+    ga.LocalWebserverAuth()
+    assert not ga.access_token_expired
+    # Test if correct credentials file is created
+    CheckCredentialsFile("credentials/2.dat")
+    time.sleep(1)
+
+
+@pytest.mark.manual
+def test_03_LocalWebServerAuthWithNoCredentialsSaving():
+    # Delete old credentials file
+    delete_file("credentials/3.dat")
+    ga = GoogleAuth(settings_file_path("test_oauth_test_03.yaml"))
+    assert not ga.settings["save_credentials"]
+    ga.LocalWebserverAuth()
+    assert not ga.access_token_expired
+    time.sleep(1)
+
+
+@pytest.mark.manual
+def test_04_CommandLineAuthWithClientConfigFromFile():
+    # Delete old credentials file
+    delete_file("credentials/4.dat")
+    # Test if authentication works with config read from file
+    ga = GoogleAuth(settings_file_path("test_oauth_test_04.yaml"))
+    ga.CommandLineAuth()
+    assert not ga.access_token_expired
+    # Test if correct credentials file is created
+    CheckCredentialsFile("credentials/4.dat")
+    time.sleep(1)
+
+
+@pytest.mark.manual
+def test_05_ConfigFromSettingsWithoutOauthScope():
+    # Test if authentication works without oauth_scope
+    ga = GoogleAuth(settings_file_path("test_oauth_test_05.yaml"))
+    ga.LocalWebserverAuth()
+    assert not ga.access_token_expired
+    time.sleep(1)
+
+
+@pytest.mark.skip(reason="P12 authentication is deprecated")
+def test_06_ServiceAuthFromSavedCredentialsP12File():
+    setup_credentials("credentials/6.dat")
+    ga = GoogleAuth(settings_file_path("test_oauth_test_06.yaml"))
+    ga.ServiceAuth()
+    assert not ga.access_token_expired
+    time.sleep(1)
+
+
+def test_07_ServiceAuthFromSavedCredentialsJsonFile():
+    # Have an initial auth so that credentials/7.dat gets saved
+    ga = GoogleAuth(settings_file_path("test_oauth_test_07.yaml"))
+    credentials_file = ga.settings["save_credentials_file"]
+    # Delete old credentials file
+    delete_file(credentials_file)
+    assert not os.path.exists(credentials_file)
+    ga.ServiceAuth()
+    assert os.path.exists(credentials_file)
+    # Secondary auth should be made only using the previously saved
+    # login info
+    ga = GoogleAuth(settings_file_path("test_oauth_test_07.yaml"))
+    ga.ServiceAuth()
+    assert not ga.access_token_expired
+    time.sleep(1)
+
+
+def CheckCredentialsFile(credentials, no_file=False):
+    ga = GoogleAuth(settings_file_path("test_oauth_default.yaml"))
+    ga.LoadCredentialsFile(credentials)
+    assert ga.access_token_expired == no_file

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ tests_requirements = [
 ]
 
 if sys.version_info >= (3, 6):
-    tests_requirements.append("black==19.10b0")
+    tests_requirements.append("black==22.3.0")
 
 setup(
     name="PyDrive2",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ tests_requirements = [
     "funcy>=1.14",
     "flake8",
     "flake8-docstrings",
+    "pytest-mock",
 ]
 
 if sys.version_info >= (3, 6):


### PR DESCRIPTION
Fixes #163 

The reason for the bug in #163 is here:

https://github.com/iterative/PyDrive2/blob/master/pydrive2/auth.py#L396-L398

The problem is that every time any thread runs `SaveCredentialsFile` when token is being refreshed it sets the new Storage object, each storage object defines the `Lock` that is being used later for `put`, `get`, and other operations that are being done with the storage (clearly we don't want multiple threads writing and / or reading the same file again).

The following situation was possible:

T1 - acquires lock A from the Storage A
T2 - waits to acquire the same lock A
T1 - saves credentials, releases lock A, and updates Storage A to Storage B and the same happens with lock, now it's lock B
(it's already not thread safe since T1 now can do some stuff in parallel with T2 since they use different locks)
T2 - acquires lock A
T2 - reads credentials
T2 - get's to the point where it needs to release lock, but credentials object now points to Storage B and it's trying to release lock B (thus "release unlocked lock" exception)

It's a critical MT bug and it's strange that it was working at all before.

TODO:

- [x] First #165 should be merged, this one will be rebased
- [x] run pre-commit
- [x] I still need to run some tests and may be even add some unit tests to safe guard this for the future.

