### PR TITLE
make checksum optional in GDriveFileSystem

### DIFF
--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -243,7 +243,11 @@ class GDriveFileSystem(AbstractFileSystem):
         else:
             metadata["type"] = "file"
             metadata["size"] = int(gdrive_file.get("fileSize"))
-            metadata["checksum"] = gdrive_file["md5Checksum"] if "md5Checksum" in gdrive_file else None
+            metadata["checksum"] = (
+                gdrive_file["md5Checksum"]
+                if "md5Checksum" in gdrive_file
+                else None
+            )
         return metadata
 
     def ls(self, path, detail=False):
@@ -276,7 +280,9 @@ class GDriveFileSystem(AbstractFileSystem):
                         "type": "file",
                         "name": item_path,
                         "size": int(item["fileSize"]),
-                        "checksum": item["md5Checksum"] if "md5Checksum" in item else None,
+                        "checksum": item["md5Checksum"]
+                        if "md5Checksum" in item
+                        else None,
                     }
                 )
 
@@ -321,7 +327,9 @@ class GDriveFileSystem(AbstractFileSystem):
                         "name": posixpath.join(bucket, item_path),
                         "type": "file",
                         "size": int(item["fileSize"]),
-                        "checksum": item["md5Checksum"] if "md5Checksum" in item else None,
+                        "checksum": item["md5Checksum"]
+                        if "md5Checksum" in item
+                        else None,
                     }
                 )
 

--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -243,11 +243,7 @@ class GDriveFileSystem(AbstractFileSystem):
         else:
             metadata["type"] = "file"
             metadata["size"] = int(gdrive_file.get("fileSize"))
-            metadata["checksum"] = (
-                gdrive_file["md5Checksum"]
-                if "md5Checksum" in gdrive_file
-                else None
-            )
+            metadata["checksum"] = gdrive_file.get("md5Checksum")
         return metadata
 
     def ls(self, path, detail=False):
@@ -280,9 +276,7 @@ class GDriveFileSystem(AbstractFileSystem):
                         "type": "file",
                         "name": item_path,
                         "size": int(item["fileSize"]),
-                        "checksum": item["md5Checksum"]
-                        if "md5Checksum" in item
-                        else None,
+                        "checksum": item.get("md5Checksum"),
                     }
                 )
 
@@ -327,9 +321,7 @@ class GDriveFileSystem(AbstractFileSystem):
                         "name": posixpath.join(bucket, item_path),
                         "type": "file",
                         "size": int(item["fileSize"]),
-                        "checksum": item["md5Checksum"]
-                        if "md5Checksum" in item
-                        else None,
+                        "checksum": item.get("md5Checksum"),
                     }
                 )
 

--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -243,7 +243,7 @@ class GDriveFileSystem(AbstractFileSystem):
         else:
             metadata["type"] = "file"
             metadata["size"] = int(gdrive_file.get("fileSize"))
-            metadata["checksum"] = gdrive_file["md5Checksum"]
+            metadata["checksum"] = gdrive_file["md5Checksum"] if "md5Checksum" in gdrive_file else None
         return metadata
 
     def ls(self, path, detail=False):
@@ -276,7 +276,7 @@ class GDriveFileSystem(AbstractFileSystem):
                         "type": "file",
                         "name": item_path,
                         "size": int(item["fileSize"]),
-                        "checksum": item["md5Checksum"],
+                        "checksum": item["md5Checksum"] if "md5Checksum" in item else None,
                     }
                 )
 
@@ -321,7 +321,7 @@ class GDriveFileSystem(AbstractFileSystem):
                         "name": posixpath.join(bucket, item_path),
                         "type": "file",
                         "size": int(item["fileSize"]),
-                        "checksum": item["md5Checksum"],
+                        "checksum": item["md5Checksum"] if "md5Checksum" in item else None,
                     }
                 )
 


### PR DESCRIPTION
As discussed in #191, to make `GDriveFileSystem` compatible with google docs / sheet files the checksum in the metadata need to be optional.

I tried to run the tests in `test_fs.py` and it's all green.