### PR TITLE
auth: add dictionary storage

### DIFF
--- a/docs/oauth.rst
+++ b/docs/oauth.rst
@@ -74,6 +74,8 @@ These are all the possible fields of a *settings.yaml* file:
     save_credentials: {{bool}}
     save_credentials_backend: {{str}}
     save_credentials_file: {{str}}
+    save_credentials_dict: {{dict}}
+    save_credentials_key: {{str}}
 
     get_refresh_token: {{bool}}
 
@@ -91,8 +93,10 @@ Fields explained:
 :client_config['redirect_uri'] (str): Redirection endpoint URI. **Default**: 'urn:ietf:wg:oauth:2.0:oob'. **Required**: No.
 :client_config['revoke_uri'] (str): Revoke endpoint URI. **Default**: None. **Required**: No.
 :save_credentials (bool): True if you want to save credentials. **Default**: False. **Required**: No.
-:save_credentials_backend (str): Backend to save credentials to. 'file' is the only valid value for now. **Default**: 'file'. **Required**: No.
+:save_credentials_backend (str): Backend to save credentials to. 'file' and 'dictionary' are the only valid values for now. **Default**: 'file'. **Required**: No.
 :save_credentials_file (str): Destination of credentials file. **Required**: Yes, only if *save_credentials_backend* is 'file'.
+:save_credentials_dict (dict): Dict to use for storing credentials. **Required**: Yes, only if *save_credentials_backend* is 'dictionary'.
+:save_credentials_key (str): Key within the *save_credentials_dict* to store the credentials in. **Required**: Yes, only if *save_credentials_backend* is 'dictionary'.
 :get_refresh_token (bool): True if you want to retrieve refresh token along with access token. **Default**: False. **Required**: No.
 :oauth_scope (list of str): OAuth scope to authenticate. **Default**: ['https://www.googleapis.com/auth/drive']. **Required**: No.
 

--- a/pydrive2/test/test_oauth.py
+++ b/pydrive2/test/test_oauth.py
@@ -125,6 +125,33 @@ def test_09_SaveLoadCredentialsUsesDefaultStorage(mocker):
     assert spy.call_count == 0
 
 
+def test_10_ServiceAuthFromSavedCredentialsDictionary():
+    creds_dict = {}
+    settings = {
+        "client_config_backend": "service",
+        "service_config": {
+            "client_json_file_path": "/tmp/pydrive2/credentials.json",
+        },
+        "oauth_scope": ["https://www.googleapis.com/auth/drive"],
+        "save_credentials": True,
+        "save_credentials_backend": "dictionary",
+        "save_credentials_dict": creds_dict,
+        "save_credentials_key": "creds",
+    }
+    ga = GoogleAuth(settings=settings)
+    ga.ServiceAuth()
+    assert not ga.access_token_expired
+    assert creds_dict
+    first_creds_dict = creds_dict.copy()
+    # Secondary auth should be made only using the previously saved
+    # login info
+    ga = GoogleAuth(settings=settings)
+    ga.ServiceAuth()
+    assert not ga.access_token_expired
+    assert creds_dict == first_creds_dict
+    time.sleep(1)
+
+
 def CheckCredentialsFile(credentials, no_file=False):
     ga = GoogleAuth(settings_file_path("test_oauth_default.yaml"))
     ga.LoadCredentialsFile(credentials)


### PR DESCRIPTION
Allows not to save anything to disk, which is useful overall but especially
useful when working with env vars, which could be sensitive so saving their
value to disk is undesirable.