### PR TITLE
auth: add client_json and client_json_dict

### DIFF
--- a/docs/oauth.rst
+++ b/docs/oauth.rst
@@ -71,6 +71,12 @@ These are all the possible fields of a *settings.yaml* file:
       redirect_uri: {{str}}
       revoke_uri: {{str}}
 
+    service_config:
+      client_user_email: {{str}}
+      client_json_file_path: {{str}}
+      client_json_dict: {{dict}}
+      client_json: {{str}}
+
     save_credentials: {{bool}}
     save_credentials_backend: {{str}}
     save_credentials_file: {{str}}
@@ -83,15 +89,20 @@ These are all the possible fields of a *settings.yaml* file:
 
 Fields explained:
 
-:client_config_backend (str): From where to read client configuration(API application settings such as client_id and client_secrets) from. Valid values are 'file' and 'settings'. **Default**: 'file'. **Required**: No.
+:client_config_backend (str): From where to read client configuration(API application settings such as client_id and client_secrets) from. Valid values are 'file', 'settings' and 'service'. **Default**: 'file'. **Required**: No.
 :client_config_file (str): When *client_config_backend* is 'file', path to the file containing client configuration. **Default**: 'client_secrets.json'. **Required**: No.
-:client_config (dict): Place holding dictionary for client configuration when *client_config_backend* is 'settings'. **Required**: Yes, only if *client_config_backend* is 'settings'
+:client_config (dict): Place holding dictionary for client configuration when *client_config_backend* is 'settings'. **Required**: Yes, only if *client_config_backend* is 'settings' and not using *service_config*
 :client_config['client_id'] (str): Client ID of the application. **Required**: Yes, only if *client_config_backend* is 'settings'
 :client_config['client_secret'] (str): Client secret of the application. **Required**: Yes, only if *client_config_backend* is 'settings'
 :client_config['auth_uri'] (str): The authorization server endpoint URI. **Default**: 'https://accounts.google.com/o/oauth2/auth'. **Required**: No.
 :client_config['token_uri'] (str): The token server endpoint URI. **Default**: 'https://accounts.google.com/o/oauth2/token'. **Required**: No.
 :client_config['redirect_uri'] (str): Redirection endpoint URI. **Default**: 'urn:ietf:wg:oauth:2.0:oob'. **Required**: No.
 :client_config['revoke_uri'] (str): Revoke endpoint URI. **Default**: None. **Required**: No.
+:service_config (dict): Place holding dictionary for client configuration when *client_config_backend* is 'service' or 'settings' and using service account. **Required**: Yes, only if *client_config_backend* is 'service' or 'settings' and not using *client_config*
+:service_config['client_user_email'] (str): User email that authority was delegated_ to. **Required**: No.
+:service_config['client_json_file_path'] (str): Path to service account `.json` key file. **Required**: No.
+:service_config['client_json_dict'] (dict): Service account `.json` key file loaded into a dictionary. **Required**: No.
+:service_config['client_json'] (str): Service account `.json` key file loaded into a string. **Required**: No.
 :save_credentials (bool): True if you want to save credentials. **Default**: False. **Required**: No.
 :save_credentials_backend (str): Backend to save credentials to. 'file' and 'dictionary' are the only valid values for now. **Default**: 'file'. **Required**: No.
 :save_credentials_file (str): Destination of credentials file. **Required**: Yes, only if *save_credentials_backend* is 'file'.
@@ -99,6 +110,8 @@ Fields explained:
 :save_credentials_key (str): Key within the *save_credentials_dict* to store the credentials in. **Required**: Yes, only if *save_credentials_backend* is 'dictionary'.
 :get_refresh_token (bool): True if you want to retrieve refresh token along with access token. **Default**: False. **Required**: No.
 :oauth_scope (list of str): OAuth scope to authenticate. **Default**: ['https://www.googleapis.com/auth/drive']. **Required**: No.
+
+.. _delegated: https://developers.google.com/admin-sdk/directory/v1/guides/delegation
 
 Sample *settings.yaml*
 ______________________

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -308,18 +308,18 @@ class GoogleAuth(ApiAttributeMixin):
         if set(self.SERVICE_CONFIGS_LIST) - set(self.client_config):
             self.LoadServiceConfigSettings()
         scopes = scopes_to_string(self.settings["oauth_scope"])
-        client_service_json = self.client_config.get("client_json_file_path")
-        creds_dict = self.client_config.get("client_creds_dict")
-        if creds_dict:
+        keyfile_name = self.client_config.get("client_json_file_path")
+        keyfile_dict = self.client_config.get("client_json_dict")
+        if keyfile_dict:
             self.credentials = (
                 ServiceAccountCredentials.from_json_keyfile_dict(
-                    keyfile_dict=creds_dict, scopes=scopes
+                    keyfile_dict=keyfile_dict, scopes=scopes
                 )
             )
-        elif client_service_json:
+        elif keyfile_name:
             self.credentials = (
                 ServiceAccountCredentials.from_json_keyfile_name(
-                    filename=client_service_json, scopes=scopes
+                    filename=keyfile_name, scopes=scopes
                 )
             )
         else:

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -1,3 +1,4 @@
+import json
 import webbrowser
 import httplib2
 import oauth2client.clientsecrets as clientsecrets
@@ -310,6 +311,12 @@ class GoogleAuth(ApiAttributeMixin):
         scopes = scopes_to_string(self.settings["oauth_scope"])
         keyfile_name = self.client_config.get("client_json_file_path")
         keyfile_dict = self.client_config.get("client_json_dict")
+        keyfile_json = self.client_config.get("client_json")
+
+        if not keyfile_dict and keyfile_json:
+            # Compensating for missing ServiceAccountCredentials.from_json_keyfile
+            keyfile_dict = json.loads(keyfile_json)
+
         if keyfile_dict:
             self.credentials = (
                 ServiceAccountCredentials.from_json_keyfile_dict(

--- a/pydrive2/settings.py
+++ b/pydrive2/settings.py
@@ -82,6 +82,7 @@ SETTINGS_STRUCT = {
                 "required": False,
                 "struct": {},
             },
+            "client_json": {"type": str, "required": False},
         },
     },
     "oauth_scope": {

--- a/pydrive2/settings.py
+++ b/pydrive2/settings.py
@@ -77,6 +77,11 @@ SETTINGS_STRUCT = {
             "client_service_email": {"type": str, "required": False},
             "client_pkcs12_file_path": {"type": str, "required": False},
             "client_json_file_path": {"type": str, "required": False},
+            "client_json_dict": {
+                "type": dict,
+                "required": False,
+                "struct": {},
+            },
         },
     },
     "oauth_scope": {

--- a/pydrive2/test/test_oauth.py
+++ b/pydrive2/test/test_oauth.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 import pytest
@@ -7,6 +8,7 @@ from pydrive2.test.test_util import (
     setup_credentials,
     delete_file,
     settings_file_path,
+    GDRIVE_USER_CREDENTIALS_DATA,
 )
 from oauth2client.file import Storage
 
@@ -149,6 +151,40 @@ def test_10_ServiceAuthFromSavedCredentialsDictionary():
     ga.ServiceAuth()
     assert not ga.access_token_expired
     assert creds_dict == first_creds_dict
+    time.sleep(1)
+
+
+def test_11_ServiceAuthFromJsonNoCredentialsSaving():
+    client_json = os.environ[GDRIVE_USER_CREDENTIALS_DATA]
+    settings = {
+        "client_config_backend": "service",
+        "service_config": {
+            "client_json": client_json,
+        },
+        "oauth_scope": ["https://www.googleapis.com/auth/drive"],
+    }
+    # Test that no credentials are saved and API is still functional
+    # We are testing that there are no exceptions at least
+    ga = GoogleAuth(settings=settings)
+    assert not ga.settings["save_credentials"]
+    ga.ServiceAuth()
+    time.sleep(1)
+
+
+def test_12_ServiceAuthFromJsonDictNoCredentialsSaving():
+    client_json_dict = json.loads(os.environ[GDRIVE_USER_CREDENTIALS_DATA])
+    settings = {
+        "client_config_backend": "service",
+        "service_config": {
+            "client_json_dict": client_json_dict,
+        },
+        "oauth_scope": ["https://www.googleapis.com/auth/drive"],
+    }
+    # Test that no credentials are saved and API is still functional
+    # We are testing that there are no exceptions at least
+    ga = GoogleAuth(settings=settings)
+    assert not ga.settings["save_credentials"]
+    ga.ServiceAuth()
     time.sleep(1)
 
 


### PR DESCRIPTION
`client_creds_dict` was introduced in experimental mode before (a few days back) and wasn't documented. Renaming it into `client_json_dict` to be consistent with other options.

Introducing `client_json` for convenience to syncronize with oauth2 storage options so that users can use either dict or json and not be forced to use both of them when authenticating.