### PR TITLE
auth: service: don't forget to load json configs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+	# NOTE: needed for pull_request_target to use PR code
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
     - uses: actions/setup-python@v4
       with:

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -571,22 +571,27 @@ class GoogleAuth(ApiAttributeMixin):
             pass  # The service auth fields are not present, handling code can go here.
 
     def LoadServiceConfigSettings(self):
-        """Loads client configuration from settings file.
+        """Loads client configuration from settings.
         :raises: InvalidConfigError
         """
-        for file_format in ["json", "pkcs12"]:
-            config = f"client_{file_format}_file_path"
+        configs = [
+            "client_json_file_path",
+            "client_json_dict",
+            "client_json",
+            "client_pkcs12_file_path",
+        ]
+
+        for config in configs:
             value = self.settings["service_config"].get(config)
             if value:
                 self.client_config[config] = value
                 break
         else:
             raise InvalidConfigError(
-                "Either json or pkcs12 file path required "
-                "for service authentication"
+                f"One of {configs} is required for service authentication"
             )
 
-        if file_format == "pkcs12":
+        if config == "client_pkcs12_file_path":
             self.SERVICE_CONFIGS_LIST.append("client_service_email")
 
         for config in self.SERVICE_CONFIGS_LIST:

--- a/pydrive2/test/test_oauth.py
+++ b/pydrive2/test/test_oauth.py
@@ -157,7 +157,7 @@ def test_10_ServiceAuthFromSavedCredentialsDictionary():
 def test_11_ServiceAuthFromJsonNoCredentialsSaving():
     client_json = os.environ[GDRIVE_USER_CREDENTIALS_DATA]
     settings = {
-        "client_config_backend": "settings",
+        "client_config_backend": "service",
         "service_config": {
             "client_json": client_json,
         },
@@ -174,7 +174,7 @@ def test_11_ServiceAuthFromJsonNoCredentialsSaving():
 def test_12_ServiceAuthFromJsonDictNoCredentialsSaving():
     client_json_dict = json.loads(os.environ[GDRIVE_USER_CREDENTIALS_DATA])
     settings = {
-        "client_config_backend": "settings",
+        "client_config_backend": "service",
         "service_config": {
             "client_json_dict": client_json_dict,
         },


### PR DESCRIPTION
If `client_user_email` is not specified - it will trigger `LoadServiceConfigSettings` call during `ServiceAuth`, which will raise an exception because it doesn't see neither `json` nor `pkcs12` keyfile path.