### PR TITLE
fs: simplify auth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ Features of PyDrive2
    classes of each resource to make your program more object-oriented.
 -  Helps common operations else than API calls, such as content fetching
    and pagination control.
+-  Provides `fsspec`_ filesystem implementation.
 
 How to install
 --------------
@@ -125,6 +126,23 @@ File listing pagination made easy
         for file1 in file_list:
             print('title: {}, id: {}'.format(file1['title'], file1['id']))
 
+Fsspec filesystem
+-----------------
+
+*PyDrive2* provides easy way to work with your files through `fsspec`_
+compatible `GDriveFileSystem`_.
+
+.. code:: python
+
+    from pydrive2.fs import GDriveFileSystem
+
+    fs = GDriveFileSystem("root", client_id=my_id, client_secret=my_secret)
+
+    for root, dnames, fnames in fs.walk(""):
+        ...
+
+.. _`GDriveFileSystem`: https://docs.iterative.ai/PyDrive2/fsspec/
+
 Concurrent access made easy
 ---------------------------
 
@@ -137,3 +155,5 @@ Thanks to all our contributors!
 
 .. image:: https://contrib.rocks/image?repo=iterative/PyDrive2
    :target: https://github.com/iterative/PyDrive2/graphs/contributors
+
+.. _`fsspec`: https://filesystem-spec.readthedocs.io/en/latest/

--- a/docs/fsspec.rst
+++ b/docs/fsspec.rst
@@ -1,0 +1,117 @@
+fsspec filesystem
+=================
+
+*PyDrive2* provides easy way to work with your files through `fsspec`_
+compatible `GDriveFileSystem`_.
+
+Installation
+------------
+
+.. code-block:: sh
+
+  pip install 'pydrive2[fsspec]'
+
+Local webserver
+---------------
+
+.. code-block:: python
+
+    from pydrive2.fs import GDriveFileSystem
+
+    fs = GDriveFileSystem(
+        "root",
+        client_id="my_client_id",
+        client_secret="my_client_secret",
+    )
+
+By default, credentials will be cached per 'client_id', but if you are using
+multiple users you might want to use 'profile' to avoid accidentally using
+someone else's cached credentials:
+
+.. code-block:: python
+
+    from pydrive2.fs import GDriveFileSystem
+
+    fs = GDriveFileSystem(
+        "root",
+        client_id="my_client_id",
+        client_secret="my_client_secret",
+        profile="myprofile",
+    )
+
+Writing cached credentials to a file and using it if it already exists (which
+avoids interactive auth):
+
+.. code-block:: python
+
+    from pydrive2.fs import GDriveFileSystem
+
+    fs = GDriveFileSystem(
+        "root",
+        client_id="my_client_id",
+        client_secret="my_client_secret",
+        client_json_file_path="/path/to/keyfile.json",
+    )
+
+Using cached credentials from json string (avoids interactive auth):
+
+.. code-block:: python
+
+    from pydrive2.fs import GDriveFileSystem
+
+    fs = GDriveFileSystem(
+        "root",
+        client_id="my_client_id",
+        client_secret="my_client_secret",
+        client_json=json_string,
+    )
+
+Service account
+---------------
+
+Using json keyfile path:
+
+.. code-block:: python
+
+    from pydrive2.fs import GDriveFileSystem
+
+    fs = GDriveFileSystem(
+        "root",
+        use_service_account=True,
+        client_json_file_path="/path/to/keyfile.json",
+    )
+
+Using json keyfile string:
+
+.. code-block:: python
+
+    from pydrive2.fs import GDriveFileSystem
+
+    fs = GDriveFileSystem(
+        "root",
+        use_service_account=True,
+        client_json=json_string,
+    )
+
+Use `client_user_email` if you are using `delegation of authority`_.
+
+Using filesystem
+----------------
+
+.. code-block:: python
+
+    for root, dnames, fnames in fs.walk(""):
+        for dname in dnames:
+            print(f"dir: {root}/{dname}")
+        
+        for fname in fnames:
+            print(f"file: {root}/{fname}")
+
+Filesystem instance offers a large number of methods for getting information
+about and manipulating files, refer to fsspec docs on
+`how to use a filesystem`_.
+
+.. _`fsspec`: https://filesystem-spec.readthedocs.io/en/latest/
+.. _`GDriveFileSystem`: /PyDrive2/pydrive2/#pydrive2.fs.GDriveFileSystem
+.. _`delegation of authority`: https://developers.google.com/admin-sdk/directory/v1/guides/delegation
+.. _`how to use a filesystem`: https://filesystem-spec.readthedocs.io/en/latest/usage.html#use-a-file-system

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,5 +44,6 @@ Table of Contents
    oauth
    filemanagement
    filelist
+   fsspec
    pydrive2
    genindex

--- a/pydrive2/test/test_fs.py
+++ b/pydrive2/test/test_fs.py
@@ -1,3 +1,4 @@
+import os
 import posixpath
 import secrets
 import uuid
@@ -8,6 +9,7 @@ import fsspec
 from pydrive2.auth import GoogleAuth
 from pydrive2.fs import GDriveFileSystem
 from pydrive2.test.test_util import settings_file_path, setup_credentials
+from pydrive2.test.test_util import GDRIVE_USER_CREDENTIALS_DATA
 
 TEST_GDRIVE_REPO_BUCKET = "root"
 
@@ -34,6 +36,34 @@ def fs(tmpdir, base_remote_dir):
     fs._gdrive_create_dir("root", base)
 
     return fs
+
+
+@pytest.mark.manual
+def test_fs_oauth(base_remote_dir):
+    GDriveFileSystem(
+        base_remote_dir,
+        client_id="47794215776-cd9ssb6a4vv5otkq6n0iadpgc4efgjb1.apps.googleusercontent.com",  # noqa: E501
+        client_secret="i2gerGA7uBjZbR08HqSOSt9Z",
+    )
+
+
+def test_fs_service_json_file(base_remote_dir):
+    creds = "credentials/fs.dat"
+    setup_credentials(creds)
+    GDriveFileSystem(
+        base_remote_dir,
+        use_service_account=True,
+        client_json_file_path=creds,
+    )
+
+
+def test_fs_service_json(base_remote_dir):
+    creds = os.environ[GDRIVE_USER_CREDENTIALS_DATA]
+    GDriveFileSystem(
+        base_remote_dir,
+        use_service_account=True,
+        client_json=creds,
+    )
 
 
 def test_info(fs, tmpdir, remote_dir):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,12 @@ setup(
         "pyOpenSSL >= 19.1.0",
     ],
     extras_require={
-        "fsspec": ["fsspec >= 2021.07.0", "tqdm >= 4.0.0", "funcy >= 1.14"],
+        "fsspec": [
+            "fsspec >= 2021.07.0",
+            "tqdm >= 4.0.0",
+            "funcy >= 1.14",
+            "appdirs >= 1.4.3",
+        ],
         "tests": tests_requirements,
     },
     python_requires=">=3.7",


### PR DESCRIPTION
Compared to how we were using it in dvc before:

1) doesn't require/accept `tmp_dir` at all, caches creds in
   `appdirs("pydrive2fs", appauthor=False)`.
2) caching is per `client_id`, so no risk of using mismatched client_id and
   cached creds. If user supplies a `profile`(defaults to `default`) - we'll
   also cache it by `profile` to support multiple google users using the same
   `client_id`.
3) renamed `service_account_json_file_path` into `client_json_file_path` for
   consistency.
4) renamed `service_account_user_email` into `client_user_email` for
   consistency.

Other than that, this is mostly old code.

Fixes https://github.com/iterative/PyDrive2/issues/193