### PR TITLE
Migrating to Google Auth Library

### DIFF
--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -1,7 +1,6 @@
 import json
 import webbrowser
 import httplib2
-import json
 import threading
 
 from googleapiclient.discovery import build
@@ -50,7 +49,7 @@ class RefreshError(AuthError):
 def LoadAuth(decoratee):
     """
     Decorator to check the self.auth & self.http object in a decorated API call.
-    Loads a new GoogleAuth or Http object if not the needed.
+    Loads a new GoogleAuth or Http object if not needed.
     """
 
     @wraps(decoratee)
@@ -138,10 +137,6 @@ class GoogleAuth(ApiAttributeMixin):
         self._default_storage = None
         self._credentials = None
 
-    # Lazy loading, read-only properties
-    # these look like functions but are actually getters for the read only properties
-    # e.g. self.service would retrun self._service
-    # however self.service = <something> would fail
     @property
     def service(self):
         if not self._service:
@@ -328,7 +323,7 @@ class GoogleAuth(ApiAttributeMixin):
         elif keyfile_name:
             self._credentials = google.oauth2.service_account.Credentials.from_service_account_file(
                 keyfile_name, **additional_config
-            )       
+            )
         else:
             raise AuthenticationError("Invalid service credentials")
 
@@ -645,7 +640,7 @@ class GoogleAuth(ApiAttributeMixin):
         :raises: RefreshError
         """
         raise DeprecationWarning(
-            "Manual refresh will be deprecated as the"
+            "Manual refresh had been deprecated as the"
             "new google auth library handles refresh automatically"
         )
 

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -26,6 +26,7 @@ from warnings import warn
 
 _CLIENT_AUTH_PROMPT_MESSAGE = "Please visit this URL:\n{url}\n"
 
+
 class AuthError(Exception):
     """Base error for authentication/authorization errors."""
 
@@ -328,6 +329,13 @@ class GoogleAuth(ApiAttributeMixin):
             self._credentials = google.oauth2.service_account.Credentials.from_service_account_file(
                 keyfile_name, **additional_config
             )
+        elif self.settings.get("use_default"):
+            # if no service credential file in yaml settings
+            # default to checking env var `GOOGLE_APPLICATION_CREDENTIALS`
+            credentials, _ = google.auth.default(
+                scopes=self.settings["oauth_scope"]
+            )
+            self._credentials = credentials
         else:
             raise AuthenticationError("Invalid service credentials")
 
@@ -639,6 +647,15 @@ class GoogleAuth(ApiAttributeMixin):
             # the oauth subject does not have to provide any consent via the client
             pass
 
+    def Refresh(self):
+        """Refreshes the access_token.
+        :raises: RefreshError
+        """
+        raise DeprecationWarning(
+            "Manual refresh will be deprecated as the"
+            "new google auth library handles refresh automatically"
+        )
+
     def GetAuthUrl(self):
         """Creates authentication url where user visits to grant access.
 
@@ -688,7 +705,7 @@ class GoogleAuth(ApiAttributeMixin):
             # catch oauth 2 errors
             print("Authentication request was rejected")
             raise AuthenticationRejected("User rejected authentication")
-        
+
         print("Authentication successful.")
 
     def _build_http(self):
@@ -711,16 +728,9 @@ class GoogleAuth(ApiAttributeMixin):
 
         :raises: AuthenticationError
         """
-        if self.access_token_expired:
-            raise AuthenticationError(
-                "No valid credentials provided to authorize"
-            )
-
-        if self.http is None:
-            self.http = self._build_http()
-        self.http = self.credentials.authorize(self.http)
-        self.service = build(
-            "drive", "v2", http=self.http, cache_discovery=False
+        raise DeprecationWarning(
+            "Manual authorization of HTTP will be deprecated as the"
+            "new google auth library handles the adding to relevant oauth headers automatically"
         )
 
     def Get_Http_Object(self):

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -629,7 +629,7 @@ class GoogleAuth:
         :raises: RefreshError
         """
         raise DeprecationWarning(
-            "Manual refresh had been deprecated as the"
+            "Manual refresh is deprecated as the"
             "new google auth library handles refresh automatically"
         )
 
@@ -653,7 +653,6 @@ class GoogleAuth:
         :raises: AuthenticationError
         """
         self.Authenticate(code)
-        self.Authorize()
 
     def Authenticate(self, code):
         """Authenticates given authentication code back from user.

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -1,5 +1,4 @@
 import json
-import webbrowser
 import httplib2
 import threading
 
@@ -9,8 +8,6 @@ import google.oauth2.credentials
 import google.oauth2.service_account
 from .storage import FileBackend, DictionaryBackend
 
-from .apiattr import ApiAttribute
-from .apiattr import ApiAttributeMixin
 from .settings import LoadSettingsFile
 from .settings import ValidateSettings
 from .settings import SettingsError
@@ -79,7 +76,7 @@ def LoadAuth(decoratee):
     return _decorated
 
 
-class GoogleAuth(ApiAttributeMixin):
+class GoogleAuth:
     """Wrapper class for oauth2client library in google-api-python-client.
 
     Loads all settings and credentials from one 'settings.yaml' file
@@ -95,13 +92,6 @@ class GoogleAuth(ApiAttributeMixin):
     }
 
     SERVICE_CONFIGS_LIST = ["client_user_email"]
-    settings = ApiAttribute("settings")
-    client_config = ApiAttribute("client_config")
-    flow = ApiAttribute("flow")
-    credentials = ApiAttribute("credentials")
-    http = ApiAttribute("http")
-    service = ApiAttribute("service")
-    auth_method = ApiAttribute("auth_method")
 
     def __init__(
         self, settings_file="settings.yaml", http_timeout=None, settings=None
@@ -117,7 +107,6 @@ class GoogleAuth(ApiAttributeMixin):
         :type settings: dict.
         """
         self.http_timeout = http_timeout
-        ApiAttributeMixin.__init__(self)
         self.thread_local = threading.local()
 
         if settings is None and settings_file:

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -328,14 +328,7 @@ class GoogleAuth(ApiAttributeMixin):
         elif keyfile_name:
             self._credentials = google.oauth2.service_account.Credentials.from_service_account_file(
                 keyfile_name, **additional_config
-            )
-        elif self.settings.get("use_default"):
-            # if no service credential file in yaml settings
-            # default to checking env var `GOOGLE_APPLICATION_CREDENTIALS`
-            credentials, _ = google.auth.default(
-                scopes=self.settings["oauth_scope"]
-            )
-            self._credentials = credentials
+            )       
         else:
             raise AuthenticationError("Invalid service credentials")
 

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -49,7 +49,7 @@ class RefreshError(AuthError):
 def LoadAuth(decoratee):
     """
     Decorator to check the self.auth & self.http object in a decorated API call.
-    Loads a new GoogleAuth or Http object if not needed.
+    Loads a new GoogleAuth or Http object if needed.
     """
 
     @wraps(decoratee)

--- a/pydrive2/auth.py
+++ b/pydrive2/auth.py
@@ -326,7 +326,7 @@ class GoogleAuth:
                     "Please specify credentials file to read"
                 )
 
-            self._storage_registry[backend] = FileBackend()
+            self._storage_registry[backend] = FileBackend(credentials_file)
 
         elif backend == "dictionary":
             creds_dict = self.settings.get("save_credentials_dict")
@@ -383,10 +383,10 @@ class GoogleAuth:
                     "file or pass an explicit value"
                 )
         else:
-            self._default_storage = FileBackend()
+            self._default_storage = FileBackend(credentials_file)
 
         try:
-            auth_info = self.default_storage.read_credentials(credentials_file)
+            auth_info = self.default_storage.read_credentials()
         except FileNotFoundError:
             # if credential was not found, raise the error for handling
             raise
@@ -468,7 +468,7 @@ class GoogleAuth:
         storage = self._storage_registry["file"]
 
         try:
-            storage.store_credentials(self._credentials, credentials_file)
+            storage.store_credentials(self._credentials)
 
         except OSError:
             raise InvalidCredentialsError(

--- a/pydrive2/auth_helpers.py
+++ b/pydrive2/auth_helpers.py
@@ -1,0 +1,58 @@
+_OLD_CLIENT_CONFIG_KEYS = frozenset(
+    (
+        "client_id",
+        "client_secret",
+        "auth_uri",
+        "token_uri",
+        "revoke_uri",
+        "redirect_uri",
+    )
+)
+
+_CLIENT_CONFIG_KEYS = frozenset(
+    (
+        "client_id",
+        "client_secret",
+        "auth_uri",
+        "token_uri",
+        "redirect_uris",
+    )
+)
+
+
+def verify_client_config(client_config, with_oauth_type=True):
+    """Verifies that format of the client config
+    loaded from a Google-format client secrets file.
+    """
+
+    oauth_type = None
+    config = client_config
+
+    if with_oauth_type:
+        if "web" in client_config:
+            oauth_type = "web"
+            config = config["web"]
+
+        elif "installed" in client_config:
+            oauth_type = "installed"
+            config = config["installed"]
+        else:
+            raise ValueError(
+                "Client secrets must be for a web or installed app"
+            )
+
+    # This is the older format of client config
+    if _OLD_CLIENT_CONFIG_KEYS.issubset(config.keys()):
+        config["redirect_uris"] = [config["redirect_uri"]]
+
+    # by default, the redirect uri is the first in the list
+    if "redirect_uri" not in config:
+        config["redirect_uri"] = config["redirect_uris"][0]
+
+    if "revoke_uri" not in config:
+        config["revoke_uri"] = "https://oauth2.googleapis.com/revoke"
+
+    if not _CLIENT_CONFIG_KEYS.issubset(config.keys()):
+        raise ValueError("Client secrets is not in the correct format.")
+
+    return oauth_type, config

--- a/pydrive2/storage.py
+++ b/pydrive2/storage.py
@@ -21,9 +21,6 @@ def validate_file(filename):
 class CredentialBackend(object):
     """Adapter that provides a consistent interface to read and write credentials"""
 
-    def __init__(self, thread_lock=None):
-        self._thread_lock = thread_lock
-
     def _read_credentials(self, **kwargs):
         """Specific implementation of how credentials are retrieved from backend"""
         return NotImplementedError
@@ -44,7 +41,7 @@ class CredentialBackend(object):
         return self._read_credentials(**kwargs)
 
     def store_credentials(self, credential, **kwargs):
-        """Write a credential to the backend as a json file"""
+        """Write a credential to the backend"""
         self._store_credentials(credential, **kwargs)
 
     def delete_credentials(self, **kwargs):
@@ -103,8 +100,7 @@ class FileBackend(CredentialBackend):
 class DictionaryBackend(CredentialBackend):
     """Read and write credentials to a dictionary backend"""
 
-    def __init__(self, dictionary, thread_lock=None):
-        super().__init__(thread_lock=thread_lock)
+    def __init__(self, dictionary):
         self._dictionary = dictionary
 
     def _read_credentials(self, key):

--- a/pydrive2/storage.py
+++ b/pydrive2/storage.py
@@ -19,7 +19,7 @@ def validate_file(filename):
 
 
 class CredentialBackend(object):
-    """Adapter that provides a consistent interface to read and write credential files"""
+    """Adapter that provides a consistent interface to read and write credentials"""
 
     def __init__(self, thread_lock=None):
         self._thread_lock = thread_lock

--- a/pydrive2/storage.py
+++ b/pydrive2/storage.py
@@ -1,0 +1,146 @@
+import os
+import json
+import warnings
+import threading
+
+
+_SYM_LINK_MESSAGE = "File: {0}: Is a symbolic link."
+_IS_DIR_MESSAGE = "{0}: Is a directory"
+_MISSING_FILE_MESSAGE = "Cannot access {0}: No such file or directory"
+
+
+def validate_file(filename):
+    if os.path.islink(filename):
+        raise IOError(_SYM_LINK_MESSAGE.format(filename))
+    elif os.path.isdir(filename):
+        raise IOError(_IS_DIR_MESSAGE.format(filename))
+    elif not os.path.isfile(filename):
+        warnings.warn(_MISSING_FILE_MESSAGE.format(filename))
+
+
+class CredentialBackend(object):
+    """Adapter that provides a consistent interface to read and write credential files"""
+
+    def __init__(self, thread_lock=None):
+        self._thread_lock = thread_lock
+
+    def _read_credentials(self, rpath):
+        """Specific implementation of how the storage object should retrieve a file."""
+        return NotImplementedError
+
+    def _store_credentials(self, credential, rpath):
+        """Specific implementation of how the storage object should write a file"""
+        return NotImplementedError
+
+    def _delete_credentials(self, rpath):
+        """Specific implementation of how the storage object should delete a file."""
+        return NotImplementedError
+
+    def read_credentials(self, rpath):
+        """Reads a credential config file and returns the config as a dictionary
+        :param fname: host name of the local web server.
+        :type host_name: str.`
+        :return: A credential file
+        """
+        return self._read_credentials(rpath)
+
+    def store_credentials(self, credential, rpath):
+        """Write a credential to
+        The Storage lock must be held when this is called.
+        Args:
+            credentials: Credentials, the credentials to store.
+        """
+        self._store_credentials(credential, rpath)
+
+    def delete_credentials(self, rpath):
+        """Delete credential.
+        Frees any resources associated with storing the credential.
+        The Storage lock must *not* be held when this is called.
+
+        Returns:
+            None
+        """
+        self._delete_credentials(rpath)
+
+
+class FileBackend(CredentialBackend):
+    """Read and write credentials to a file backend with Thread-locking"""
+
+    def __init__(self):
+        super().__init__(thread_lock=threading.Lock())
+
+    def _create_file_if_needed(self, rpath):
+        """Create an empty file if necessary.
+        This method will not initialize the file. Instead it implements a
+        simple version of "touch" to ensure the file has been created.
+        """
+        if not os.path.exists(rpath):
+            old_umask = os.umask(0o177)
+            try:
+                open(rpath, "a+b").close()
+            finally:
+                os.umask(old_umask)
+
+    def _read_credentials(self, rpath):
+        """Reads a local json file and parses the information into a info dictionary.
+        Returns:
+        Raises:
+        """
+        with self._thread_lock:
+            validate_file(rpath)
+            with open(rpath, "r") as json_file:
+                return json.load(json_file)
+
+    def _store_credentials(self, credentials, rpath):
+        """Writes current credentials to a local json file.
+        Args:
+        Raises:
+        """
+        with self._thread_lock:
+            # write new credentials to the temp file
+            dirname, filename = os.path.split(rpath)
+            temp_path = os.path.join(dirname, "temp_{}".format(filename))
+            self._create_file_if_needed(temp_path)
+
+            with open(temp_path, "w") as json_file:
+                json_file.write(credentials.to_json())
+
+            # replace the existing credential file
+            os.replace(temp_path, rpath)
+
+    def _delete_credentials(self, rpath):
+        """Delete Credentials file.
+        Args:
+            credentials: Credentials, the credentials to store.
+        """
+        with self._thread_lock:
+            os.unlink(rpath)
+
+
+class DictionaryBackend(CredentialBackend):
+    """Read and write credentials to a dictionary backend"""
+
+    def __init__(self, dictionary, thread_lock=None):
+        super().__init__(thread_lock=thread_lock)
+        self._dictionary = dictionary
+
+    def _read_credentials(self, rpath):
+        """Reads a local json file and parses the information into a info dictionary.
+        Returns:
+        Raises:
+        """
+        return self._dictionary.get(rpath)
+
+    def _store_credentials(self, credentials, rpath):
+        """Writes current credentials to a local json file.
+        Args:
+        Raises:
+        """
+        self._dictionary[rpath] = credentials.to_json()
+
+    def _delete_credentials(self, rpath):
+        """Delete Credentials file.
+        Args:
+            credentials: Credentials, the credentials to store.
+        """
+        self._dictionary.pop(rpath, None)

--- a/pydrive2/test/settings/default_user.yaml
+++ b/pydrive2/test/settings/default_user.yaml
@@ -1,0 +1,11 @@
+client_config_backend: file
+client_config_file: /tmp/pydrive2/user.json
+
+save_credentials: True
+save_credentials_backend: file
+save_credentials_file: credentials/default_user.dat
+
+oauth_scope:
+  - https://www.googleapis.com/auth/drive
+
+get_refresh_token: True

--- a/pydrive2/test/settings/default_user_no_refresh.yaml
+++ b/pydrive2/test/settings/default_user_no_refresh.yaml
@@ -1,0 +1,9 @@
+client_config_backend: file
+client_config_file: /tmp/pydrive2/user.json
+
+save_credentials: True
+save_credentials_backend: file
+save_credentials_file: credentials/default_user_no_refresh.dat
+
+oauth_scope:
+  - https://www.googleapis.com/auth/drive

--- a/pydrive2/test/test_oauth_custom.py
+++ b/pydrive2/test/test_oauth_custom.py
@@ -1,0 +1,42 @@
+import pytest
+import os
+from pydrive2.auth import GoogleAuth
+from pydrive2.drive import GoogleDrive
+from pydrive2.test.test_util import (
+    settings_file_path,
+    setup_credentials,
+    delete_file,
+)
+
+
+@pytest.fixture
+def googleauth_preauth():
+    setup_credentials()
+    # Delete old credentials file
+    delete_file("credentials/default_user.dat")
+    ga = GoogleAuth(settings_file_path("default_user.yaml"))
+
+    return ga
+
+
+@pytest.mark.manual
+def test_01_CustomAuthWithSavingOfCredentials(googleauth_preauth):
+
+    credentials_file = googleauth_preauth.settings["save_credentials_file"]
+
+    assert not os.path.exists(credentials_file)
+
+    auth_url, state = googleauth_preauth.GetAuthUrl()
+    print("please visit this url: {}".format(auth_url))
+
+    googleauth_preauth.Authenticate(input("Please enter the auth code: "))
+
+    # credentials have been loaded
+    assert googleauth_preauth.credentials
+    # check that credentials file has been saved
+    assert os.path.exists(credentials_file)
+
+    gdrive = GoogleDrive(googleauth_preauth)
+
+    about_object = gdrive.GetAbout()
+    assert about_object is not None

--- a/pydrive2/test/test_token_expiry.py
+++ b/pydrive2/test/test_token_expiry.py
@@ -1,0 +1,77 @@
+import pytest
+from pydrive2.auth import GoogleAuth
+from pydrive2.drive import GoogleDrive
+from pydrive2.test.test_util import (
+    settings_file_path,
+    setup_credentials,
+    pydrive_retry,
+    delete_file,
+)
+from google.auth.exceptions import RefreshError
+
+
+@pytest.fixture
+def googleauth_refresh():
+    setup_credentials()
+    # Delete old credentials file
+    delete_file("credentials/default_user.dat")
+    ga = GoogleAuth(settings_file_path("default_user.yaml"))
+    ga.LocalWebserverAuth()
+
+    return ga
+
+
+@pytest.fixture
+def googleauth_no_refresh():
+    setup_credentials()
+    # Delete old credentials file
+    delete_file("credentials/default_user_no_refresh.dat")
+    ga = GoogleAuth(settings_file_path("default_user_no_refresh.yaml"))
+    ga.LocalWebserverAuth()
+
+    return ga
+
+
+@pytest.mark.manual
+def test_01_TokenExpiryWithRefreshToken(googleauth_refresh):
+    gdrive = GoogleDrive(googleauth_refresh)
+
+    about_object = pydrive_retry(gdrive.GetAbout)
+    assert about_object is not None
+
+    # save the first access token for comparison
+    token1 = gdrive.auth.credentials.token
+
+    # simulate token expiry by deleting the underlying token
+    gdrive.auth.credentials.token = None
+
+    # credential object should still exist but access token expired
+    assert gdrive.auth.credentials
+    assert gdrive.auth.access_token_expired
+
+    about_object = pydrive_retry(gdrive.GetAbout)
+    assert about_object is not None
+
+    # save the second access token for comparison
+    token2 = gdrive.auth.credentials.token
+
+    assert token1 != token2
+
+
+@pytest.mark.manual
+def test_02_TokenExpiryWithoutRefreshToken(googleauth_no_refresh):
+    gdrive = GoogleDrive(googleauth_no_refresh)
+
+    about_object = pydrive_retry(gdrive.GetAbout)
+    assert about_object is not None
+
+    # simulate token expiry by deleting the underlying token
+    gdrive.auth.credentials.token = None
+
+    # credential object should still exist but access token expired
+    assert gdrive.auth.credentials
+    assert gdrive.auth.access_token_expired
+
+    # as credentials have no refresh token, this would fail
+    with pytest.raises(RefreshError) as e_info:
+        about_object = pydrive_retry(gdrive.GetAbout)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     long_description_content_type="text/x-rst",
     install_requires=[
         "google-api-python-client >= 1.12.5",
-        "oauth2client >= 4.0.0",
+        "google-auth",
+        "google-auth-oauthlib",
         "PyYAML >= 3.0",
         "pyOpenSSL >= 19.1.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     long_description_content_type="text/x-rst",
     install_requires=[
         "google-api-python-client >= 1.12.5",
-        "six >= 1.13.0",
         "oauth2client >= 4.0.0",
         "PyYAML >= 3.0",
         "pyOpenSSL >= 19.1.0",


### PR DESCRIPTION
### Summary of changes

#89 
- Removed all dependencies on oauth2client and transitioned to the use of google-auth

#89 
- Added a thread-safe backend adaptor for saving of authorized credentials to File / Dictionary Backend
- Only authorized user credentials can be saved to backend
- Service credential are not saved because of private key duplication risks

#173 
- Deprecate command line auth by raising a DeprecationWarning Exception
  
**Removing manual refresh & authorization header injection code as this is now handle by the Google Auth library**
- Removal of CheckAuth & CheckServiceAuth decorators
- Deprecation of `self.Refresh()`  & `self.Authorize()` methods
- Update `self.Get_Http_Object()` method to use the `AuthorizedHttp` object from google's [HTTP migration helper library](https://github.com/googleapis/google-auth-library-python-httplib2)
