### PR TITLE
rebuild `cp_file` in `GDriveFileSystem` to use `GoogleDriveFile.Copy` 

### DIFF
--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -548,9 +548,7 @@ class GDriveFileSystem(AbstractFileSystem):
             file.Copy(dst_parent, posixpath.basename(rpath.rstrip("/")))
 
     def mkdir(self, path, create_parents=True, **kwargs):
-        """
-        Create directory entry at path
-        """
+        """Create directory entry at path"""
 
         if self.exists(path):
             raise FileExistsError(path)

--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -541,12 +541,23 @@ class GDriveFileSystem(AbstractFileSystem):
         file = self.client.CreateFile({"id": file_id})
 
         if file["mimeType"] == FOLDER_MIME_TYPE:
-            dst_id = self._get_item_id(self._parent(rpath))
-            self._gdrive_create_dir(dst_id, posixpath.basename(rpath))
+            self.mkdir(rpath)
         else:
             dst_parent_id = self._get_item_id(self._parent(rpath), create=True)
             dst_parent = self.client.CreateFile({"id": dst_parent_id})
-            file.Copy(dst_parent, posixpath.basename(rpath))
+            file.Copy(dst_parent, posixpath.basename(rpath.rstrip("/")))
+
+    def mkdir(self, path, create_parents=True, **kwargs):
+        """
+        Create directory entry at path
+        """
+
+        if self.exists(path):
+            raise FileExistsError(path)
+
+        dst_id = self._get_item_id(self._parent(path), create=create_parents)
+        basename = posixpath.basename(path.rstrip("/"))
+        self._gdrive_create_dir(dst_id, basename)
 
     def get_file(self, lpath, rpath, callback=None, block_size=None, **kwargs):
         item_id = self._get_item_id(lpath)

--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -542,11 +542,11 @@ class GDriveFileSystem(AbstractFileSystem):
 
         if file["mimeType"] == FOLDER_MIME_TYPE:
             dst_id = self._get_item_id(self._parent(rpath))
-            self._gdrive_create_dir(dst_id, rpath.split("/")[-1])
+            self._gdrive_create_dir(dst_id, posixpath.basename(rpath))
         else:
             dst_parent_id = self._get_item_id(self._parent(rpath), create=True)
             dst_parent = self.client.CreateFile({"id": dst_parent_id})
-            file.Copy(dst_parent, rpath.split("/")[-1])
+            file.Copy(dst_parent, posixpath.basename(rpath))
 
     def get_file(self, lpath, rpath, callback=None, block_size=None, **kwargs):
         item_id = self._get_item_id(lpath)

--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -536,9 +536,6 @@ class GDriveFileSystem(AbstractFileSystem):
     def cp_file(self, lpath, rpath, **kwargs):
         """copy a single file or folder"""
 
-        if self.exists(rpath):
-            raise FileExistsError(rpath)
-
         file_id = self._get_item_id(lpath)
 
         file = self.client.CreateFile({"id": file_id})

--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -549,7 +549,7 @@ class GDriveFileSystem(AbstractFileSystem):
         else:
             dst_parent_id = self._get_item_id(self._parent(rpath), create=True)
             dst_parent = self.client.CreateFile({"id": dst_parent_id})
-            file.Copy(dst_parent, file["title"])
+            file.Copy(dst_parent, rpath.split("/")[-1])
 
     def get_file(self, lpath, rpath, callback=None, block_size=None, **kwargs):
         item_id = self._get_item_id(lpath)


### PR DESCRIPTION
Can copy single files and folders, the recursive implementation is in `AbstractFileSystem.copy`.

Is compatible with `AbstractFileSystem.copy` so for example:

```python
fs = GDriveFileSystem("root/tmp", auth)

fs.copy('root/tmp/a.pdf', 'root/tmp/folder/b.pdf', recursive=False)
> will copy the file file a.pdf in the folder and rename it to b.pdf

fs.copy('root/tmp/folder1', 'root/tmp/folder/new_folder1', recursive=True)
> will copy the folder folder1 into folder, renaming it new_folder1. will also copy the content 
> of folder1 into new_folder1
```


There are no tests for copy, but there is one for the `move` method, that right now is implemented as `copy + rm`, and the test passes.

todo list:

- [ ] add tests

@shcheklein can you please review the code? Also check if this is backward compatible with the previous implementation.

Thank you. 

