### PR TITLE
[skip ci]: use gh-action-pypi-publish@release/v1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,6 @@ jobs:
 
     - name: Publish
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
See https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-.