### PR TITLE
pyinstaller: add package hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,5 +7,5 @@ repos:
 - hooks:
   - id: flake8
     language_version: python3
-  repo: https://gitlab.com/pycqa/flake8
-  rev: 4.0.1
+  repo: https://github.com/PyCQA/flake8
+  rev: 5.0.4

--- a/pydrive2/__pyinstaller/__init__.py
+++ b/pydrive2/__pyinstaller/__init__.py
@@ -1,0 +1,9 @@
+import os
+
+
+def get_hook_dirs():
+    return [os.path.dirname(__file__)]
+
+
+def get_PyInstaller_tests():
+    return [os.path.dirname(__file__)]

--- a/pydrive2/__pyinstaller/hook-googleapiclient.py
+++ b/pydrive2/__pyinstaller/hook-googleapiclient.py
@@ -1,0 +1,9 @@
+from PyInstaller.utils.hooks import (  # pylint: disable=import-error
+    copy_metadata,
+    collect_data_files,
+)
+
+datas = copy_metadata("google-api-python-client")
+datas += collect_data_files(
+    "googleapiclient", excludes=["*.txt", "**/__pycache__"]
+)

--- a/pydrive2/__pyinstaller/test_hook-googleapiclient.py
+++ b/pydrive2/__pyinstaller/test_hook-googleapiclient.py
@@ -1,0 +1,35 @@
+import subprocess
+
+from PyInstaller import __main__ as pyi_main
+
+
+_APP_SOURCE = """import importlib.resources
+
+import pydrive2.files
+
+
+cache_files = importlib.resources.contents(
+    "googleapiclient.discovery_cache.documents"
+)
+assert len(cache_files) > 0
+"""
+
+
+def test_pyi_hook_google_api_client(tmp_path):
+    app_name = "userapp"
+    workpath = tmp_path / "build"
+    distpath = tmp_path / "dist"
+    app = tmp_path / f"{app_name}.py"
+    app.write_text(_APP_SOURCE)
+    pyi_main.run(
+        [
+            "--workpath",
+            str(workpath),
+            "--distpath",
+            str(distpath),
+            "--specpath",
+            str(tmp_path),
+            str(app),
+        ],
+    )
+    subprocess.run([str(distpath / app_name / app_name)], check=True)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ tests_requirements = [
     "flake8",
     "flake8-docstrings",
     "pytest-mock",
+    "pyinstaller",
 ]
 
 tests_requirements.append("black==22.10.0")
@@ -18,7 +19,12 @@ setup(
     author_email="jgwak@dreamylab.com",
     maintainer="DVC team",
     maintainer_email="support@dvc.org",
-    packages=["pydrive2", "pydrive2.test", "pydrive2.fs"],
+    packages=[
+        "pydrive2",
+        "pydrive2.test",
+        "pydrive2.fs",
+        "pydrive2.__pyinstaller",
+    ],
     url="https://github.com/iterative/PyDrive2",
     project_urls={
         "Documentation": "https://docs.iterative.ai/PyDrive2",
@@ -52,4 +58,10 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
+    entry_points={
+        "pyinstaller40": [
+            "hook-dirs = pydrive2.__pyinstaller:get_hook_dirs",
+            "tests = pydrive2.__pyinstaller:get_PyInstaller_tests",
+        ]
+    },
 )


### PR DESCRIPTION
Adds package level pyinstaller hooks so that any downstream package using pydrive2 + pyinstaller does not need to define their own hooks for the google client APIs

see details in the pyinstaller docs: https://pyinstaller.org/en/stable/hooks.html#providing-pyinstaller-hooks-with-your-package)

related:
https://github.com/iterative/PyDrive2/issues/197
https://github.com/iterative/dvc/issues/7949
