### PR TITLE
fix(upload): returns broken `downloadUrl`

### DIFF
--- a/pydrive2/apiattr.py
+++ b/pydrive2/apiattr.py
@@ -80,7 +80,10 @@ class ApiResource(dict):
 
     def update(self, *args, **kwargs):
         """Overwritten method of dictionary."""
+        BAD_URL_PREFIX = "https://www.googleapis.comhttps:"
         for k, v in dict(*args, **kwargs).items():
+            if k == "downloadUrl" and v.startswith(BAD_URL_PREFIX):
+                v = v.replace(BAD_URL_PREFIX, "https://www.googleapis.com", 1)
             self[k] = v
 
     def UpdateMetadata(self, metadata=None):


### PR DESCRIPTION
This code:

```
             self.auth.service.files()
                .insert(**param)
                .execute(http=self.http)
```

That is used here https://github.com/iterative/PyDrive2/blob/main/pydrive2/files.py#L678-L680

Started returning metadata object with download URL like this:

`'downloadUrl': 'https://www.googleapis.com/drive/v2/files/16USPEjsYg7WEL3J62p4N4TRE5_ZMr3SW?alt=media&source=downloadUrl'`

That was breaking the download content later that is relying on the `downloadUrl` here:

https://github.com/iterative/PyDrive2/blob/main/pydrive2/files.py#L476

And it's visible in the tests, e.g. here: https://github.com/iterative/PyDrive2/pull/269

I hope it's a temporary patch and it will be fixed upstream soon. It might be related to the deprecated v2 of the API which we don't have capacity at the moment to fix :(



