### PR TITLE
fix(upload/272): don't magically set filename on set file content

### DIFF
--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -257,8 +257,6 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
         :type filename: str.
         """
         self.content = open(filename, "rb")
-        if self.get("title") is None:
-            self["title"] = filename
         if self.get("mimeType") is None:
             self["mimeType"] = mimetypes.guess_type(filename)[0]
 

--- a/pydrive2/test/test_file.py
+++ b/pydrive2/test/test_file.py
@@ -264,6 +264,26 @@ class GoogleDriveFileTest(unittest.TestCase):
 
         self.DeleteUploadedFiles(drive, [file1["id"]])
 
+    def test_Files_Update_File_Keeps_Filename(self):
+        # Tests https://github.com/iterative/PyDrive2/issues/272
+        drive = GoogleDrive(self.ga)
+        file1 = drive.CreateFile()
+        filename = self.getTempFile("preupdatetestfile")
+        contentFile = self.getTempFile("actual_content", "some string")
+        contentFile2 = self.getTempFile("actual_content_2", "some string")
+
+        file1["title"] = filename
+        file1.SetContentFile(contentFile)
+        pydrive_retry(file1.Upload)  # Files.insert
+        self.assertEqual(file1.metadata["title"], filename)
+
+        same_file = drive.CreateFile({"id": file1["id"]})
+        same_file.SetContentFile(contentFile2)
+        pydrive_retry(same_file.Upload)  # Files.update
+        self.assertEqual(same_file.metadata["title"], filename)
+
+        self.DeleteUploadedFiles(drive, [file1["id"]])
+
     def test_Files_Update_By_Id(self):
         drive = GoogleDrive(self.ga)
         file1 = drive.CreateFile()


### PR DESCRIPTION
Fixes #272 

I don't see a good reason to keep this behavior. Magic that is not consistent with other `Set*Content` methods. 

Downside of this approach is that it breaks the compatibility a bit. Let's see how it goes, we might release a major / minor version.

--------

TODO:

- [x] Add tests
- [x] Check docs and examples
- [ ] Bump at least a minor version after release since it changes the behavior a bit