### PR TITLE
Set content picks default title/mime if file is created for the first time

### DIFF
--- a/docs/filemanagement.rst
+++ b/docs/filemanagement.rst
@@ -9,8 +9,7 @@ Manipulate file metadata and contents from `GoogleDriveFile`_ object and call
 Upload a new file
 -----------------
 
-Here is a sample code to upload a file. ``gauth`` is an authenticated
-`GoogleAuth`_ object.
+Here is a sample code to upload a file. ``gauth`` is an authenticated `GoogleAuth`_ object.
 
 .. code-block:: python
 
@@ -25,13 +24,9 @@ Here is a sample code to upload a file. ``gauth`` is an authenticated
     print('title: %s, id: %s' % (file1['title'], file1['id']))
     # title: Hello.txt, id: {{FILE_ID}}
 
-Now, you will have a file 'Hello.txt' uploaded to your Google Drive. You can
-open it from web interface to check its content, 'Hello World!'.
+Now, you will have a file 'Hello.txt' uploaded to your Google Drive. You can open it from web interface to check its content, 'Hello World!'.
 
-Note that `CreateFile()`_ will create `GoogleDriveFile`_ instance but not
-actually upload a file to Google Drive. You can initialize `GoogleDriveFile`_
-object by itself. However, it is not recommended to do so in order to keep
-authentication consistent.
+Note that `CreateFile()`_ will create `GoogleDriveFile`_ instance but not actually upload a file to Google Drive. You can initialize `GoogleDriveFile`_ object by itself. However, it is not recommended to do so in order to keep authentication consistent.
 
 Delete, Trash and un-Trash files
 --------------------------------
@@ -54,9 +49,8 @@ You may want to delete, trash, or un-trash a file. To do this use ``Delete()``,
 Update file metadata
 --------------------
 
-You can manipulate file metadata from a `GoogleDriveFile`_ object just as you
-manipulate a ``dict``. The format of file metadata can be found in the Google
-Drive API documentation: `Files resource`_.
+You can manipulate file metadata from a `GoogleDriveFile`_ object just as you manipulate a ``dict``.
+The format of file metadata can be found in the Google Drive API documentation: `Files resource`_.
 
 Sample code continues from `Upload a new file`_:
 
@@ -222,8 +216,8 @@ Sample code continues from `Download file metadata from file ID`_:
     print('title: %s, mimeType: %s' % (file5['title'], file5['mimeType']))
     # title: cat.png, mimeType: image/png
 
-**Advanced Users:** If you call ``SetContentFile`` and ``GetContentFile`` you
-can define which character encoding is to be used by using the optional
+**Advanced Users:** If you call SetContentFile and GetContentFile you can can
+define which character encoding is to be used by using the optional
 parameter `encoding`.
 
 If you, for example, are retrieving a file which is stored on your Google

--- a/docs/filemanagement.rst
+++ b/docs/filemanagement.rst
@@ -9,7 +9,8 @@ Manipulate file metadata and contents from `GoogleDriveFile`_ object and call
 Upload a new file
 -----------------
 
-Here is a sample code to upload a file. ``gauth`` is an authenticated `GoogleAuth`_ object.
+Here is a sample code to upload a file. ``gauth`` is an authenticated
+`GoogleAuth`_ object.
 
 .. code-block:: python
 
@@ -24,9 +25,13 @@ Here is a sample code to upload a file. ``gauth`` is an authenticated `GoogleAut
     print('title: %s, id: %s' % (file1['title'], file1['id']))
     # title: Hello.txt, id: {{FILE_ID}}
 
-Now, you will have a file 'Hello.txt' uploaded to your Google Drive. You can open it from web interface to check its content, 'Hello World!'.
+Now, you will have a file 'Hello.txt' uploaded to your Google Drive. You can
+open it from web interface to check its content, 'Hello World!'.
 
-Note that `CreateFile()`_ will create `GoogleDriveFile`_ instance but not actually upload a file to Google Drive. You can initialize `GoogleDriveFile`_ object by itself. However, it is not recommended to do so in order to keep authentication consistent.
+Note that `CreateFile()`_ will create `GoogleDriveFile`_ instance but not
+actually upload a file to Google Drive. You can initialize `GoogleDriveFile`_
+object by itself. However, it is not recommended to do so in order to keep
+authentication consistent.
 
 Delete, Trash and un-Trash files
 --------------------------------
@@ -49,8 +54,9 @@ You may want to delete, trash, or un-trash a file. To do this use ``Delete()``,
 Update file metadata
 --------------------
 
-You can manipulate file metadata from a `GoogleDriveFile`_ object just as you manipulate a ``dict``.
-The format of file metadata can be found in the Google Drive API documentation: `Files resource`_.
+You can manipulate file metadata from a `GoogleDriveFile`_ object just as you
+manipulate a ``dict``. The format of file metadata can be found in the Google
+Drive API documentation: `Files resource`_.
 
 Sample code continues from `Upload a new file`_:
 
@@ -216,8 +222,8 @@ Sample code continues from `Download file metadata from file ID`_:
     print('title: %s, mimeType: %s' % (file5['title'], file5['mimeType']))
     # title: cat.png, mimeType: image/png
 
-**Advanced Users:** If you call SetContentFile and GetContentFile you can can
-define which character encoding is to be used by using the optional
+**Advanced Users:** If you call ``SetContentFile`` and ``GetContentFile`` you
+can define which character encoding is to be used by using the optional
 parameter `encoding`.
 
 If you, for example, are retrieving a file which is stored on your Google

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -1,4 +1,5 @@
 import io
+import os
 import mimetypes
 import json
 
@@ -261,7 +262,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
         self.content = open(filename, "rb")
         if self.get("id") is None:
             if self.get("title") is None:
-                self["title"] = filename
+                self["title"] = os.path.basename(filename)
             if self.get("mimeType") is None:
                 self["mimeType"] = mimetypes.guess_type(filename)[0]
 

--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -235,7 +235,8 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
         """Set content of this file to be a string.
 
         Creates io.BytesIO instance of utf-8 encoded string.
-        Sets mimeType to be 'text/plain' if not specified.
+        Sets mimeType to be 'text/plain' if not specified and file id is not
+        set (means that we are uploading this file for the first time).
 
         :param encoding: The encoding to use when setting the content of this file.
         :type encoding: str
@@ -243,7 +244,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
         :type content: str
         """
         self.content = io.BytesIO(content.encode(encoding))
-        if self.get("mimeType") is None:
+        if self.get("mimeType") is None and self.get("id") is None:
             self["mimeType"] = "text/plain"
 
     def SetContentFile(self, filename):
@@ -251,14 +252,18 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
 
         Opens the file specified by this method.
         Will be read, uploaded, and closed by Upload() method.
-        Sets metadata 'title' and 'mimeType' automatically if not specified.
+        Sets metadata 'title' and 'mimeType' automatically if not specified and
+        the file is uploaded for the first time (id is not set).
 
         :param filename: name of the file to be uploaded.
         :type filename: str.
         """
         self.content = open(filename, "rb")
-        if self.get("mimeType") is None:
-            self["mimeType"] = mimetypes.guess_type(filename)[0]
+        if self.get("id") is None:
+            if self.get("title") is None:
+                self["title"] = filename
+            if self.get("mimeType") is None:
+                self["mimeType"] = mimetypes.guess_type(filename)[0]
 
     def GetContentString(
         self, mimetype=None, encoding="utf-8", remove_bom=False

--- a/pydrive2/test/test_file.py
+++ b/pydrive2/test/test_file.py
@@ -129,13 +129,13 @@ class GoogleDriveFileTest(unittest.TestCase):
     def test_Files_Insert_Content_File(self):
         drive = GoogleDrive(self.ga)
         file1 = drive.CreateFile()
-        filename = self.getTempFile("filecontent")
-        file1["title"] = filename
         contentFile = self.getTempFile("actual_content", "some string")
         file1.SetContentFile(contentFile)
         pydrive_retry(file1.Upload)  # Files.insert
 
-        self.assertEqual(file1.metadata["title"], filename)
+        self.assertEqual(
+            file1.metadata["title"], os.path.basename(contentFile)
+        )
         pydrive_retry(
             file1.FetchContent
         )  # Force download and double check content.


### PR DESCRIPTION
Fixes #272 . Followup after #273 . 

Trying a bit less dramatic change. It should not be breaking backward compatibility and is fixing #272 as a regression.

