### PR TITLE
GDriveFileSystem: Raise `FIleNotFoundError` on `ls`.

### DIFF
--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -434,7 +434,7 @@ class GDriveFileSystem(AbstractFileSystem):
             dir_ids = self._path_to_item_ids(base)
 
         if not dir_ids:
-            return None
+            raise FileNotFoundError
 
         root_path = posixpath.join(bucket, base)
         contents = []

--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -434,7 +434,9 @@ class GDriveFileSystem(AbstractFileSystem):
             dir_ids = self._path_to_item_ids(base)
 
         if not dir_ids:
-            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), path
+            )
 
         root_path = posixpath.join(bucket, base)
         contents = []

--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -434,7 +434,7 @@ class GDriveFileSystem(AbstractFileSystem):
             dir_ids = self._path_to_item_ids(base)
 
         if not dir_ids:
-            raise FileNotFoundError
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
 
         root_path = posixpath.join(bucket, base)
         contents = []

--- a/pydrive2/test/test_fs.py
+++ b/pydrive2/test/test_fs.py
@@ -116,9 +116,11 @@ def test_rm(fs, remote_dir):
     assert not fs.exists(remote_dir + "/dir/c/a")
 
 
-def test_ls(fs, remote_dir):
-    fs.mkdir(remote_dir + "dir/")
+def test_ls(fs: GDriveFileSystem, remote_dir):
+    _, base = fs.split_path(remote_dir + "dir/")
+    fs._path_to_item_ids(base, create=True)
     assert fs.ls(remote_dir + "dir/") == []
+
     files = set()
     for no in range(8):
         file = remote_dir + f"dir/test_{no}"

--- a/pydrive2/test/test_fs.py
+++ b/pydrive2/test/test_fs.py
@@ -138,6 +138,11 @@ def test_ls(fs, remote_dir):
     assert dirs == expected
 
 
+def test_ls_non_existing_dir(fs, remote_dir):
+    with pytest.raises(FileNotFoundError):
+        fs.ls(remote_dir + "dir/")
+
+
 def test_find(fs, remote_dir):
     fs.mkdir(remote_dir + "/dir")
 

--- a/pydrive2/test/test_fs.py
+++ b/pydrive2/test/test_fs.py
@@ -118,6 +118,7 @@ def test_rm(fs, remote_dir):
 
 def test_ls(fs, remote_dir):
     fs.mkdir(remote_dir + "dir/")
+    assert fs.ls(remote_dir + "dir/") == []
     files = set()
     for no in range(8):
         file = remote_dir + f"dir/test_{no}"


### PR DESCRIPTION
Per https://github.com/iterative/dvc-gdrive/issues/29