### PR TITLE
fs.find: cache path ids

### DIFF
--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -473,6 +473,11 @@ class GDriveFileSystem(AbstractFileSystem):
         bucket, base = self.split_path(path)
 
         seen_paths = set()
+        cached = base in self._ids_cache["dirs"]
+        if not cached:
+            dir_ids = self._path_to_item_ids(base)
+            self._cache_path_id(base, *dir_ids)
+
         dir_ids = [self._ids_cache["ids"].copy()]
         contents = []
         while dir_ids:


### PR DESCRIPTION
GDriveFileSystem was previously caching dir ids of root, and was using those on `fs.find()`.
This worked well when the remote cache was at the root, but now since dvc uses `/files/md5/` by default, the dir ids are no longer in the cache and `find` ends up returning an empty list.

This PR checks if the path is cached, and if not, it caches the ID of the path.

Tests passes for dvc in https://github.com/iterative/dvc-gdrive/pull/28
