### PR TITLE
ci: temporarily pin to Python 3.7.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-22.04, macos-11, windows-2019]
-        pyv: ["3.7", "3.8", "3.9", "3.10"]
+        pyv: ["3.7.16", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
See https://github.com/actions/setup-python/issues/682 and https://github.com/fsspec/filesystem_spec/pull/1295.