### PR TITLE
fs: synchronize updates to cache

### DIFF
--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -265,6 +265,7 @@ class GDriveFileSystem(AbstractFileSystem):
 
         return cache
 
+    @wrap_prop(threading.RLock())
     def _cache_path_id(self, path, *item_ids, cache=None):
         cache = cache or self._ids_cache
         for item_id in item_ids:


### PR DESCRIPTION
https://github.com/iterative/PyDrive2/pull/286/files/b9fc857613ee18cd08e32c691933a82f5f371e79#r1239272908

Looks like we need to synchronize cache updates, if we expect `dirs` and `ids` to be in sync.