### PR TITLE
pydrive2: use isinstance() instead of type()

### DIFF
--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -285,7 +285,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
         """
         if (
             self.content is None
-            or type(self.content) is not io.BytesIO
+            or not isinstance(self.content, io.BytesIO)
             or self.has_bom == remove_bom
         ):
             self.FetchContent(mimetype, remove_bom)

--- a/pydrive2/settings.py
+++ b/pydrive2/settings.py
@@ -167,7 +167,7 @@ def _ValidateSettingsElement(data, struct, key):
         else:
             data[key] = default
     # If data exists, Check type of the data
-    elif type(value) is not data_type:
+    elif not isinstance(value, data_type):
         raise InvalidConfigError(f"Setting {key} should be type {data_type}")
     # If type of this data is dict, check if structure of the data is valid.
     if data_type is dict:
@@ -175,7 +175,7 @@ def _ValidateSettingsElement(data, struct, key):
     # If type of this data is list, check if all values in the list is valid.
     elif data_type is list:
         for element in data[key]:
-            if type(element) is not struct[key]["struct"]:
+            if not isinstance(element, struct[key]["struct"]):
                 raise InvalidConfigError(
                     "Setting %s should be list of %s"
                     % (key, struct[key]["struct"])


### PR DESCRIPTION
Looks like this was an anti pattern that stuck around from some early days.

Fixes https://github.com/iterative/dvc-gdrive/issues/31