### PR TITLE
prevent tags from publishing without creating releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,5 @@ jobs:
         --outdir dist/ .
 
     - name: Publish
-      if: startsWith(github.ref, 'refs/tags')
+      if: github.event.action == 'published'
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Similar to how we do in dvc.

https://github.com/iterative/dvc/blob/7c898cfad707f973f8318182c99e52285bc49bff/.github/workflows/build.yaml#L76