### PR TITLE
fix(fs): remove DVC-specific broken cache optimization

### DIFF
--- a/pydrive2/fs/spec.py
+++ b/pydrive2/fs/spec.py
@@ -256,13 +256,6 @@ class GDriveFileSystem(AbstractFileSystem):
         }
 
         self._cache_path_id(self.base, cache["root_id"], cache=cache)
-
-        for item in self._gdrive_list(
-            "'{}' in parents and trashed=false".format(cache["root_id"])
-        ):
-            item_path = posixpath.join(self.base, item["title"])
-            self._cache_path_id(item_path, item["id"], cache=cache)
-
         return cache
 
     def _cache_path_id(self, path, *item_ids, cache=None):
@@ -392,9 +385,7 @@ class GDriveFileSystem(AbstractFileSystem):
             return cached[0]
 
         item = self._gdrive_create_dir(parent_id, title)
-
-        if parent_id == self._ids_cache["root_id"]:
-            self._cache_path_id(remote_path, item["id"])
+        self._cache_path_id(remote_path, item["id"])
 
         return item["id"]
 


### PR DESCRIPTION
To mitigate https://github.com/iterative/dvc-gdrive/issues/38

It removes the pre-caching logic of `root/00`, `root/01`, .... `root/ff` DVC cache specific directories. It existed to optimize number of API calls, specifically when we use `exists` calls on the DVC transfer side and we have to do 2x calls in some simple scenarios. It's slower and expensive.

With this PR cache is becoming more general (e.g. we cache all directories we create). It makes sense for `fsspec`. To make it clear - the whole `fsspec` implementation in general case is still very broken and it'll be addressed step by step eventually.

The optimization can be turned back on with ad additional "pre_cache_path" argument. But let's do it after we fix the basic GDrive scenario with this one.