### PR TITLE
chore(fs): add tests to cover recent PRs

### DIFF
--- a/pydrive2/test/test_util.py
+++ b/pydrive2/test/test_util.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import random
 import re
 import os
@@ -29,7 +30,8 @@ def setup_credentials(credentials_path=DEFAULT_USER_CREDENTIALS_FILE):
 
 def settings_file_path(settings_file, wkdir=LOCAL_PATH):
     template_path = SETTINGS_PATH + settings_file
-    local_path = wkdir + settings_file
+    wkdir = Path(wkdir)
+    local_path = wkdir / settings_file
     assert os.path.exists(template_path)
     if not os.path.exists(wkdir):
         os.makedirs(wkdir, exist_ok=True)


### PR DESCRIPTION
Tests for the recent PR regressions:

https://github.com/iterative/PyDrive2/pull/322
https://github.com/iterative/PyDrive2/pull/321

Also seems that https://github.com/iterative/PyDrive2/issues/229 is fixed now. This PR also covers a basic test for it. @simone-viozzi please confirm if / when you have time.

Closes https://github.com/iterative/PyDrive2/issues/229

