### PR TITLE
Partial compatibility with Google security update 2021

### DIFF
--- a/pydrive2/files.py
+++ b/pydrive2/files.py
@@ -453,16 +453,14 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
 
         if file_id:
             try:
-                metadata = (
-                    self.auth.service.files()
-                    .get(
-                        fileId=file_id,
-                        fields=fields,
-                        # Teamdrive support
-                        supportsAllDrives=True,
-                    )
-                    .execute(http=self.http)
+                request = self.auth.service.files().get(
+                    fileId=file_id,
+                    fields=fields,
+                    # Teamdrive support
+                    supportsAllDrives=True,
                 )
+                request = self._AddResourceKeyHeaders(request)
+                metadata = request.execute(http=self.http)
             except errors.HttpError as error:
                 raise ApiRequestError(error)
             else:
@@ -687,6 +685,24 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
         """
         if self.http:
             request.http = self.http
+        request = self._AddResourceKeyHeaders(request)
+        return request
+
+    def _AddResourceKeyHeaders(self, request):
+        """Add resourceKey headers to request if file is secured with resourceKey and
+        its available (from a list for example).
+
+        :param request: request to add headers to.
+        :type request: googleapiclient.http.HttpRequest
+        """
+        file_id = self.metadata.get("id") or self.get("id")
+        resourceKey = self.metadata.get("resourceKey") or self.get(
+            "resourceKey"
+        )
+        if file_id and resourceKey:
+            request.headers["X-Goog-Drive-Resource-Keys"] = (
+                f"{file_id}/{resourceKey}"
+            )
         return request
 
     @LoadAuth

--- a/pydrive2/test/test_file.py
+++ b/pydrive2/test/test_file.py
@@ -356,6 +356,87 @@ class GoogleDriveFileTest(unittest.TestCase):
 
         self.DeleteUploadedFiles(drive, [file1["id"]])
 
+    def test_Files_Get_Content_Buffer_resourceKey_missing(self):
+        """404 expected for file secured with resourceKey when not provided."""
+        drive = GoogleDrive(self.ga)
+        file1 = drive.CreateFile(
+            {
+                "id": "0BxphPoRgwhnodHNjS3JESnFNS1E",
+            }
+        )
+        with self.assertRaisesRegex(
+            ApiRequestError, "HttpError 404 when requesting"
+        ):
+            pydrive_retry(file1.GetContentIOBuffer)
+
+    def test_Files_Get_Content_Buffer_resourceKey(self):
+        drive = GoogleDrive(self.ga)
+        file1 = drive.CreateFile(
+            {
+                "id": "0BxphPoRgwhnodHNjS3JESnFNS1E",
+                "resourceKey": "0-vjzOveuin3fnf4LUlfsD3A",
+            }
+        )
+
+        buffer1 = pydrive_retry(file1.GetContentIOBuffer)
+
+        self.assertEqual(len(buffer1), 6128902)
+
+    def test_Files_Get_Content_File_resourceKey_missing(self):
+        """404 expected for file secured with resourceKey when not provided."""
+        drive = GoogleDrive(self.ga)
+        file1 = drive.CreateFile(
+            {
+                "id": "0BxphPoRgwhnodHNjS3JESnFNS1E",
+            }
+        )
+        fileOut = self.getTempFile()
+        with self.assertRaisesRegex(
+            ApiRequestError, "HttpError 404 when requesting"
+        ):
+            pydrive_retry(file1.GetContentFile, fileOut)
+
+    def test_Files_Get_Content_File_resourceKey(self):
+        drive = GoogleDrive(self.ga)
+        file1 = drive.CreateFile(
+            {
+                "id": "0BxphPoRgwhnodHNjS3JESnFNS1E",
+                "resourceKey": "0-vjzOveuin3fnf4LUlfsD3A",
+            }
+        )
+
+        fileOut = self.getTempFile()
+        pydrive_retry(file1.GetContentFile, fileOut)
+
+        with open(fileOut, "rb") as f:
+            self.assertEqual(len(f.read()), 6128902)
+
+    def test_Files_Fetch_Metadata_resourceKey_missing(self):
+        """404 expected for file secured with resourceKey when not provided."""
+        drive = GoogleDrive(self.ga)
+        file1 = drive.CreateFile(
+            {
+                "id": "0BxphPoRgwhnodHNjS3JESnFNS1E",
+            }
+        )
+        with self.assertRaisesRegex(
+            ApiRequestError, "HttpError 404 when requesting"
+        ):
+            pydrive_retry(file1.FetchMetadata)
+
+    def test_Files_Fetch_Metadata_Buffer_resourceKey(self):
+        drive = GoogleDrive(self.ga)
+        file1 = drive.CreateFile(
+            {
+                "id": "0BxphPoRgwhnodHNjS3JESnFNS1E",
+                "resourceKey": "0-vjzOveuin3fnf4LUlfsD3A",
+            }
+        )
+
+        pydrive_retry(file1.FetchMetadata)
+
+        self.assertEqual(file1.metadata["title"], "N48E012.zip")
+
     def test_Upload_Download_Empty_File(self):
         filename = os.path.join(self.tmpdir, str(time()))
         create_file(filename, "")


### PR DESCRIPTION
Google Drive added a new "resourceKey" attribute required to access documents shared by links. This resourceKey must be passed through HTTP header, aside with the document ID. resourceKey can be retrieved from a previous list operation on containing folder. Partial implementation; only for basic methods: GetContentFile, GetContentIOBuffer and FetchMetadata.

Ref. 
- #129 
- https://developers.google.com/drive/api/guides/resource-keys
- https://issuetracker.google.com/issues/312938132

Few remarks:
- As the unit tests of PyDrive2 rely on actual Google Drive API usage, I've used an existing public document which I know is impacted. It could be smaller though...
- I only implemented the basic read operations because they're easy to test with a read-only public file. I'm not sure we can create a file requiring resourceKey using the API (as I understand it's for files shared by link only), and don't see how we can simply/safely use a publicly writable shared document. And let's be honest, I only need one of them :)
- At a first glance I feel GetContentFile could be refactored to rely on GetContentIOBuffer, avoiding some code duplication