### PR TITLE
fix(deps): pin pyopenssl due to incompatible changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
         "google-api-python-client >= 1.12.5",
         "oauth2client >= 4.0.0",
         "PyYAML >= 3.0",
-        "pyOpenSSL >= 19.1.0, <=24.2.1", # https://github.com/iterative/PyDrive2/issues/361
+        # https://github.com/iterative/PyDrive2/issues/361
+        "pyOpenSSL >= 19.1.0, <=24.2.1",
     ],
     extras_require={
         "fsspec": [

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "google-api-python-client >= 1.12.5",
         "oauth2client >= 4.0.0",
         "PyYAML >= 3.0",
-        "pyOpenSSL >= 19.1.0",
+        "pyOpenSSL >= 19.1.0, <=24.2.1", # https://github.com/iterative/PyDrive2/issues/361
     ],
     extras_require={
         "fsspec": [


### PR DESCRIPTION
Mitigates https://github.com/iterative/PyDrive2/issues/361

As a quick fix pin pyopenssl for now.

We need to migrate out of https://github.com/googleapis/oauth2client that is long time deprecated and is causing all these issues. Most likely there were already draft PRs for this. If someone from the community can help with that - it would be amazing.