### PR TITLE
set upper bound for cryptography

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "oauth2client >= 4.0.0",
         "PyYAML >= 3.0",
         # https://github.com/iterative/PyDrive2/issues/361
+        "cryptography<44,
         "pyOpenSSL >= 19.1.0, <=24.2.1",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "oauth2client >= 4.0.0",
         "PyYAML >= 3.0",
         # https://github.com/iterative/PyDrive2/issues/361
-        "cryptography<44,
+        "cryptography<44",
         "pyOpenSSL >= 19.1.0, <=24.2.1",
     ],
     extras_require={


### PR DESCRIPTION
pyopenssl<24.3.0 is not compatible with cryptography<44. So, limiting them so that newer version of cryptography does not get installed with older version of pyopenssl.

Related: #361.