### PR TITLE
[docs] Fix three broken links & update to Google Workspace Developer URLs

### DIFF
--- a/docs/filelist.rst
+++ b/docs/filelist.rst
@@ -43,6 +43,6 @@ Sample code continues from above:
 
 .. _`GoogleDriveFile`: /PyDrive2/pydrive2/#pydrive2.files.GoogleDriveFile
 .. _`GoogleDriveFileList`: /PyDrive2/pydrive2/#pydrive2.files.GoogleDriveFileList
-.. _`parameters of Files.list()`: https://developers.google.com/drive/v2/reference/files/list#request
+.. _`parameters of Files.list()`: https://developers.google.com/workspace/drive/api/reference/rest/v2/files/list#request
 .. _`GetList()`: /PyDrive2/pydrive2/#pydrive2.apiattr.ApiResourceList.GetList
-.. _`search for files`: https://developers.google.com/drive/api/v2/search-files
+.. _`search for files`: https://developers.google.com/workspace/drive/api/guides/search-files

--- a/docs/filelist.rst
+++ b/docs/filelist.rst
@@ -8,7 +8,7 @@ Get all files which matches the query
 
 Create `GoogleDriveFileList`_ instance with `parameters of Files.list()`_ as ``dict``. 
 Call `GetList()`_ and you will get all files that matches your query as a list of `GoogleDriveFile`_.
-The syntax and possible option of the query ``q`` parameter can be found in `search for files` Google documentation.
+The syntax and possible option of the query ``q`` parameter can be found in `search for files`_ Google documentation.
 
 .. code-block:: python
 

--- a/docs/filemanagement.rst
+++ b/docs/filemanagement.rst
@@ -178,8 +178,9 @@ Get files by complex queries
 We can get a file by name and by other constraints, usually a filename will be
 unique but we can have two equal names with different extensions, e.g.,
 *123.jpeg and 123.mp3*. So if you expect only one file add more constraints to
-the query, see `Query string examples <query_parameters>`_, as a result we get
-a list of `GoogleDriveFile`_ instances.
+the query, see
+`Query string examples <https://developers.google.com/workspace/drive/api/guides/search-files#examples>`_,
+as a result we get a list of `GoogleDriveFile`_ instances.
 
 .. code-block:: python
 
@@ -346,4 +347,3 @@ it you indicate that you acknowledge the risks of downloading potential malware.
 .. _`official documentation`: https://developers.google.com/workspace/drive/api/reference/rest/v2/files#resource-representations
 .. _`known`: https://productforums.google.com/forum/#!topic/docs/BJLimQDGtjQ
 .. _`abusive`: https://support.google.com/docs/answer/148505
-.. _`query_parameters`: https://developers.google.com/workspace/drive/api/guides/search-files#examples

--- a/docs/filemanagement.rst
+++ b/docs/filemanagement.rst
@@ -345,5 +345,5 @@ it you indicate that you acknowledge the risks of downloading potential malware.
 .. _`GetContentFile(filename)`: /PyDrive2/pydrive2/#pydrive2.files.GoogleDriveFile.GetContentFile
 .. _`GetContentString()`: /PyDrive2/pydrive2/#pydrive2.files.GoogleDriveFile.GetContentString
 .. _`official documentation`: https://developers.google.com/workspace/drive/api/reference/rest/v2/files#resource-representations
-.. _`known`: https://productforums.google.com/forum/#!topic/docs/BJLimQDGtjQ
+.. _`known`: https://github.com/googleapis/google-api-nodejs-client/issues/2404
 .. _`abusive`: https://support.google.com/docs/answer/148505

--- a/docs/filemanagement.rst
+++ b/docs/filemanagement.rst
@@ -126,7 +126,7 @@ Note: ``InsertPermission()`` calls ``GetPermissions()`` after successfully
 inserting the permission.
 
 You can find more information on the permitted fields of a permission
-`here <https://developers.google.com/drive/v2/reference/permissions/insert#request-body>`_.
+`here <https://developers.google.com/workspace/drive/api/reference/rest/v2/permissions/insert#request-body>`_.
 This file is now shared and anyone with the link can view it. But what if you
 want to check whether a file is already shared?
 
@@ -338,12 +338,12 @@ it you indicate that you acknowledge the risks of downloading potential malware.
 .. _`Upload()`: /PyDrive2/pydrive2/#pydrive2.files.GoogleDriveFile.Upload
 .. _`GoogleAuth`: /PyDrive2/pydrive2/#pydrive2.auth.GoogleAuth
 .. _`CreateFile()`: /PyDrive2/pydrive2/#pydrive2.drive.GoogleDrive.CreateFile
-.. _`Files resource`: https://developers.google.com/drive/v2/reference/files#resource-representations
+.. _`Files resource`: https://developers.google.com/workspace/drive/api/reference/rest/v2/files#resource-representations
 .. _`SetContentFile(filename)`: /PyDrive2/pydrive2/#pydrive2.files.GoogleDriveFile.SetContentFile
 .. _`SetContentString(content)`: /PyDrive2/pydrive2/#pydrive2.files.GoogleDriveFile.SetContentString
 .. _`GetContentFile(filename)`: /PyDrive2/pydrive2/#pydrive2.files.GoogleDriveFile.GetContentFile
 .. _`GetContentString()`: /PyDrive2/pydrive2/#pydrive2.files.GoogleDriveFile.GetContentString
-.. _`official documentation`: https://developers.google.com/drive/v2/reference/files#resource-representations
+.. _`official documentation`: https://developers.google.com/workspace/drive/api/reference/rest/v2/files#resource-representations
 .. _`known`: https://productforums.google.com/forum/#!topic/docs/BJLimQDGtjQ
 .. _`abusive`: https://support.google.com/docs/answer/148505
-.. _`query_parameters`: https://developers.google.com/drive/api/guides/search-files#examples
+.. _`query_parameters`: https://developers.google.com/workspace/drive/api/guides/search-files#examples

--- a/docs/fsspec.rst
+++ b/docs/fsspec.rst
@@ -122,6 +122,6 @@ about and manipulating files, refer to fsspec docs on
 
 .. _`fsspec`: https://filesystem-spec.readthedocs.io/en/latest/
 .. _`GDriveFileSystem`: /PyDrive2/pydrive2/#pydrive2.fs.GDriveFileSystem
-.. _`delegation of authority`: https://developers.google.com/admin-sdk/directory/v1/guides/delegation
+.. _`delegation of authority`: https://developers.google.com/workspace/guides/create-credentials
 .. _`Abusive files`: /PyDrive2/filemanagement/index.html#abusive-files
 .. _`how to use a filesystem`: https://filesystem-spec.readthedocs.io/en/latest/usage.html#use-a-file-system

--- a/docs/oauth.rst
+++ b/docs/oauth.rst
@@ -111,7 +111,7 @@ Fields explained:
 :get_refresh_token (bool): True if you want to retrieve refresh token along with access token. **Default**: False. **Required**: No.
 :oauth_scope (list of str): OAuth scope to authenticate. **Default**: ['https://www.googleapis.com/auth/drive']. **Required**: No.
 
-.. _delegated: https://developers.google.com/admin-sdk/directory/v1/guides/delegation
+.. _delegated: https://developers.google.com/workspace/guides/create-credentials
 
 Sample *settings.yaml*
 ______________________


### PR DESCRIPTION
This PR fixes:
- The broken "Query string examples" link [here](https://docs.iterative.ai/PyDrive2/filemanagement/#get-files-by-complex-queries).
- The "search for files" link [here](https://docs.iterative.ai/PyDrive2/filelist/#get-all-files-which-matches-the-query) which is incorrectly formatted as italics.
- Updates the existing `https://developers.google.com/drive/...` links to the new `https://developers.google.com/workspace/drive/...` links that the existing links are now automatically redirecting to.
- Replaces this broken [Google Forum thread link](https://productforums.google.com/forum/#!topic/docs/BJLimQDGtjQ) about byte order marks with an [alternative link](https://github.com/googleapis/google-api-nodejs-client/issues/2404) that can be used instead
